### PR TITLE
Add sorting functionality to favourite coins table

### DIFF
--- a/.github/workflows/ci-laravel.yml
+++ b/.github/workflows/ci-laravel.yml
@@ -39,17 +39,21 @@ jobs:
           extensions: mbstring, bcmath, pdo, mysql
           tools: composer:v2
 
-      - name: 📦 Install dependencies
+      - name: ♻️ Cache Node Modules
+        uses: actions/cache@v3
+        with:
+          path: ./laravel/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('./laravel/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: 📦 Install PHP dependencies
         working-directory: ./laravel
         run: composer install --prefer-dist --no-progress --no-suggest
 
-      - name: 🧪 Run Pint (format check)
+      - name: 📦 Install NPM dependencies
         working-directory: ./laravel
-        run: vendor/bin/pint --test
-
-      - name: 🧠 Run PHPStan (static analysis)
-        working-directory: ./laravel
-        run: vendor/bin/phpstan analyse --no-progress --configuration=phpstan.neon
+        run: npm install
 
       - name: 🛠 Copy .env
         working-directory: ./laravel
@@ -59,9 +63,21 @@ jobs:
         working-directory: ./laravel
         run: php artisan key:generate
 
+      - name: 🧱 Build Vite assets
+        working-directory: ./laravel
+        run: npm run build
+
       - name: 🧱 Run migrations
         working-directory: ./laravel
         run: php artisan migrate --force
+
+      - name: 🧪 Run Pint (format check)
+        working-directory: ./laravel
+        run: vendor/bin/pint --test
+
+      - name: 🧠 Run PHPStan (static analysis)
+        working-directory: ./laravel
+        run: vendor/bin/phpstan analyse --no-progress --configuration=phpstan.neon
 
       - name: 🧪 Run tests
         working-directory: ./laravel

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -11,7 +11,14 @@
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
+        "sass-embedded": "^1.89.2",
         "tailwindcss": "^4.0.0",
         "vite": "^6.2.4"
+    },
+    "dependencies": {
+        "datatables.net": "^2.3.2",
+        "datatables.net-bs5": "^2.3.2",
+        "jquery": "^3.7.1",
+        "toastr": "^2.1.4"
     }
 }

--- a/laravel/resources/js/app.js
+++ b/laravel/resources/js/app.js
@@ -1,1 +1,7 @@
 import './bootstrap';
+import '../scss/app.scss';
+
+// Import coins.index
+if (window.location.pathname.includes('/coins')) {
+    import('./pages/coins/index.js');
+}

--- a/laravel/resources/js/pages/coins/index.js
+++ b/laravel/resources/js/pages/coins/index.js
@@ -1,0 +1,83 @@
+import $ from 'jquery';
+import 'datatables.net-bs5';
+import toastr from 'toastr';
+
+$(function () {
+    const table = $('.datatable').DataTable({
+        order: [],
+        columnDefs: [
+            { orderable: false, targets: 4 },
+            { targets: '_all', orderSequence: ['asc', 'desc', ''] }
+        ]
+    });
+
+    /**
+     * Update sorting icons in table header based on current DataTable order.
+     *
+     * - Reset all icons to default (neutral state).
+     * - Highlight active sort column with up/down icon and color.
+     * - Handle 3rd click (reset state) by showing default icon again.
+     */
+    const updateSortIcons = () => {
+        const order = table.order(); // Current order: e.g., [[0, 'asc']]
+
+        // Reset all icons to default
+        $('thead th').each(function (index) {
+            const icon = $(this).find('i.fas');
+
+            if (!icon.length) return;
+
+            icon
+                .removeClass('fa-sort fa-sort-up fa-sort-down text-primary')
+                .addClass('fa-sort text-muted');
+        });
+
+        // Apply icon only if a column is currently sorted
+        if (order.length && order[0].length === 2) {
+            const [colIndex, dir] = order[0];
+
+            if (dir === 'asc' || dir === 'desc') {
+                const th = $('thead th').eq(colIndex);
+                const icon = th.find('i.fas');
+
+                if (icon.length) {
+                    icon.removeClass('fa-sort text-muted');
+                    icon.addClass(dir === 'asc' ? 'fa-sort-up text-primary' : 'fa-sort-down text-primary');
+                }
+            }
+        }
+    };
+
+    updateSortIcons();
+    table.on('order.dt', updateSortIcons);
+
+    // Handle favorite toggle
+    $('.favorite-toggle').on('click', function (e) {
+        e.preventDefault();
+
+        const symbol = $(this).data('symbol');
+        const icon = $(this).find('i');
+        const toggleFavoriteUrl = $('meta[name="toggle-favorite-url"]').attr('content');
+        const csrfToken = $('meta[name="csrf-token"]').attr('content');
+
+        $.ajax({
+            url: toggleFavoriteUrl,
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': csrfToken
+            },
+            data: { symbol },
+            success: function (response) {
+                if (response.success) {
+                    icon.toggleClass('fas text-danger far text-muted');
+                    toastr.success(response.message);
+                } else {
+                    toastr.error(response.message || 'Something went wrong.');
+                }
+            },
+            error: function () {
+                toastr.error('Server error. Please try again.');
+            }
+        });
+    });
+});

--- a/laravel/resources/scss/app.scss
+++ b/laravel/resources/scss/app.scss
@@ -1,0 +1,1 @@
+@use './pages/coins/index';

--- a/laravel/resources/scss/pages/coins/index.scss
+++ b/laravel/resources/scss/pages/coins/index.scss
@@ -1,0 +1,21 @@
+.table-responsive {
+    overflow-x: unset;
+
+    table.dataTable thead th {
+        position: relative;
+        padding-right: 24px;
+    
+        &::after {
+            content: '';
+            font-family: "Font Awesome 5 Free";
+            font-weight: 900;
+            font-size: 0.75rem;
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            opacity: 0.4;
+            pointer-events: none;
+        }
+    }
+}

--- a/laravel/resources/views/coins/index.blade.php
+++ b/laravel/resources/views/coins/index.blade.php
@@ -2,19 +2,23 @@
 
 @section('title', 'Top Coins')
 
+@push('meta')
+    <meta name="toggle-favorite-url" content="{{ route('favorites.toggle') }}">
+@endpush
+
 @section('content_header')
     <h1>Top Coins (Source: {{ ucfirst($source) }})</h1>
 @endsection
 
 @section('content')
     <div class="table-responsive">
-        <table class="table table-bordered table-striped">
+        <table class="table table-bordered table-striped datatable">
             <thead>
                 <tr>
-                    <th>Symbol</th>
-                    <th>Price</th>
-                    <th>Volume</th>
-                    <th>Change (%)</th>
+                    <th data-column="0">Symbol <i class="fas fa-sort text-muted ms-1"></i></th>
+                    <th data-column="1">Price <i class="fas fa-sort text-muted ms-1"></i></th>
+                    <th data-column="2">Volume <i class="fas fa-sort text-muted ms-1"></i></th>
+                    <th data-column="3">Change (%) <i class="fas fa-sort text-muted ms-1"></i></th>
                     <th>Favourite</th>
                 </tr>
             </thead>
@@ -40,45 +44,3 @@
         </table>
     </div>
 @endsection
-
-@push('page_js')
-    <script>
-        const toggleFavoriteUrl = @json(route('favorites.toggle'));
-
-        $(function () {
-            $('.favorite-toggle').on('click', function (e) {
-                e.preventDefault();
-
-                const symbol = $(this).data('symbol');
-                const icon = $(this).find('i');
-
-                $.ajax({
-                    url: toggleFavoriteUrl,
-                    method: 'POST',
-                    headers: {
-                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
-                    },
-                    data: {
-                        symbol: symbol
-                    },
-                    success: function (response) {
-                        if (response.success) {
-                            if (icon.hasClass('fas')) {
-                                icon.removeClass('fas text-danger').addClass('far text-muted');
-                            } else {
-                                icon.removeClass('far text-muted').addClass('fas text-danger');
-                            }
-                            toastr.success(response.message);
-                        } else {
-                            toastr.error(response.message || 'Something went wrong.');
-                        }
-                    },
-                    error: function () {
-                        toastr.error('Server error. Please try again.');
-                    }
-                });
-            });
-        });
-    </script>
-@endpush
-

--- a/laravel/resources/views/layouts/app.blade.php
+++ b/laravel/resources/views/layouts/app.blade.php
@@ -4,12 +4,19 @@
 @section('css')
     <!-- Global CSS -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
+    
     @stack('page_css')
+
+    @stack('meta')
+
+    @vite(['resources/scss/app.scss'])
 @endsection
 
 @section('js')
     <!-- Global JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
+    <!-- DataTables -->
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 
     <!-- Handle Laravel flash messages -->
     <script>
@@ -31,4 +38,6 @@
     </script>
 
     @stack('page_js')
+
+    @vite(['resources/js/app.js'])
 @endsection

--- a/laravel/vite.config.js
+++ b/laravel/vite.config.js
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/js/app.js', 'resources/scss/app.scss'],
+            input: ['resources/js/app.js', 'resources/scss/app.scss', 'resources/css/app.css'],
             refresh: true,
         }),
         tailwindcss(),

--- a/laravel/vite.config.js
+++ b/laravel/vite.config.js
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/js/app.js', 'resources/scss/app.scss'],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
### Description
Implement sorting for the favourite coins table so that users can easily organize the list.

### Acceptance Criteria
- User can sort by:
  - Coin name (A-Z, Z-A)
  - Price (ascending, descending)
  - 24h change (%)
- Sorting should persist across pagination (if any)
- Sorting is done at backend via query parameters
