### PR TITLE
Add TikTok node to n8n workflow

### DIFF
--- a/n8n/nodes/package.json
+++ b/n8n/nodes/package.json
@@ -2,6 +2,7 @@
   "name": "installed-nodes",
   "private": true,
   "dependencies": {
+    "@igabm/n8n-nodes-tiktok": "^1.5.0",
     "n8n-nodes-puppeteer": "1.4.1"
   }
 }


### PR DESCRIPTION
This PR adds a new TikTok node to n8n for automating content posting.
- Adds dependency @igabm/n8n-nodes-tiktok
- Updates package.json and node_modules
- Tested on local n8n instance

No breaking changes expected.
