### PR TITLE
Add Ollama model bootstrap scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,28 @@ Launches browser with:
 - isolated profile  
 - Puppeteer-ready environment  
 
+### 🤖 Ollama Model Bootstrap (Local AI)
+
+Pull required local models into the persistent Ollama volume (`./docker/ollama`) so n8n can call them.
+
+- macOS/Linux: `ollama-pull-models.sh`
+- Windows: `ollama-pull-models.ps1`
+
+Usage (macOS/Linux):
+```bash
+bash scripts/ollama-pull-models.sh
+```
+
+Usage (Windows PowerShell):
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\ollama-pull-models.ps1
+```
+
+Verify:
+```bash
+docker exec -it ollama ollama list
+```
+
 ### 🔧 Other helpers coming soon:
 - db sync scripts  
 - translation pipelines  

--- a/scripts/ollama-pull-models.ps1
+++ b/scripts/ollama-pull-models.ps1
@@ -1,0 +1,53 @@
+$ErrorActionPreference = "Stop"
+
+# Move to repo root (script can run from anywhere)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Resolve-Path "$ScriptDir\..")
+
+$OllamaContainer = $env:OLLAMA_CONTAINER
+if ([string]::IsNullOrWhiteSpace($OllamaContainer)) { $OllamaContainer = "ollama" }
+
+# Default models if none provided
+$Models = $args
+if ($Models.Count -eq 0) {
+  $Models = @("qwen2.5:7b", "mistral:7b")
+}
+
+Write-Host "==> Starting ollama container (if not running)..."
+docker compose up -d ollama | Out-Host
+
+Write-Host "==> Waiting for Ollama to be ready..."
+$Ready = $false
+for ($i=0; $i -lt 60; $i++) {
+  try {
+    docker exec $OllamaContainer ollama list *> $null
+    $Ready = $true
+    break
+  } catch {
+    Start-Sleep -Seconds 1
+  }
+}
+
+if (-not $Ready) {
+  Write-Host "❌ Ollama did not become ready in time."
+  Write-Host "Try: docker compose logs -f ollama"
+  exit 1
+}
+
+Write-Host "==> Pulling models..."
+foreach ($m in $Models) {
+  Write-Host "---- Pull: $m"
+  try {
+    docker exec -it $OllamaContainer ollama pull $m | Out-Host
+  } catch {
+    Write-Host "❌ Failed to pull model: $m"
+    Write-Host "Installed models:"
+    try { docker exec -it $OllamaContainer ollama list | Out-Host } catch {}
+    exit 1
+  }
+}
+
+Write-Host "==> Installed models:"
+docker exec -it $OllamaContainer ollama list | Out-Host
+
+Write-Host "✅ Done. n8n can call: http://ollama:11434/api/chat"

--- a/scripts/ollama-pull-models.sh
+++ b/scripts/ollama-pull-models.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make sure we're in repo root (script can run from anywhere)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Config
+OLLAMA_CONTAINER="${OLLAMA_CONTAINER:-ollama}"
+MODELS_DEFAULT=("qwen2.5:7b" "mistral:7b")
+MODELS=("${@:-${MODELS_DEFAULT[@]}}")
+
+command -v docker >/dev/null 2>&1 || { echo "❌ docker not found"; exit 1; }
+
+echo "==> Starting ollama container (if not running)..."
+docker compose up -d ollama
+
+echo "==> Waiting for Ollama API..."
+READY=0
+for i in {1..60}; do
+  if docker exec "$OLLAMA_CONTAINER" sh -lc "ollama list >/dev/null 2>&1"; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$READY" -ne 1 ]]; then
+  echo "❌ Ollama did not become ready in time."
+  echo "Try: docker compose logs -f ollama"
+  exit 1
+fi
+
+echo "==> Pulling models into ./docker/ollama (persistent volume)..."
+for m in "${MODELS[@]}"; do
+  echo "---- Pull: $m"
+  docker exec -it "$OLLAMA_CONTAINER" ollama pull "$m" || {
+    echo "❌ Failed to pull model: $m"
+    echo "Available local models:"
+    docker exec -it "$OLLAMA_CONTAINER" ollama list || true
+    exit 1
+  }
+done
+
+echo "==> Installed models:"
+docker exec -it "$OLLAMA_CONTAINER" ollama list
+
+echo "✅ Done. n8n can call: http://ollama:11434/api/chat"


### PR DESCRIPTION
## Summary

This PR adds helper scripts and documentation to bootstrap required Ollama models into the persistent Docker volume so that n8n can use local LLMs via the Ollama service.

## Changes

- Added `scripts/ollama-pull-models.sh` for macOS/Linux
- Added `scripts/ollama-pull-models.ps1` for Windows (PowerShell)
- Updated README with:
  - Usage examples for both platforms
  - Verification step using `docker exec -it ollama ollama list`

## How to test

macOS/Linux:
```bash
scripts/ollama-pull-models.sh
```

Windows:
```powershell
-ExecutionPolicy Bypass -File scripts\ollama-pull-models.ps1
```

Verify models:
```bash
docker exec -it ollama ollama list
```

Notes
- Scripts target the persistent Ollama Docker volume (./docker/ollama) so models only need to be pulled once.
- Open to feedback on naming, structure, or additional models to bootstrap.