### PR TITLE
AUTH-02: finalize admin authentication settings screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Agent Rules
 
-Read [docs/CODEGEN-RULES.md](docs/CODEGEN-RULES.md) before making application code changes.
+Read [docs/codegen-rules.md](docs/codegen-rules.md) before making application code changes.
 
-When working on `apps/laravel`, follow that document for:
-- config and secret placement
-- controller / service / repository boundaries
-- database change patterns
-- function structure and docblock requirements
-- auth and provider implementation rules
-- required `pint` and `phpstan` verification before closing a task
+When working on `apps/laravel`, use that index and read only the relevant rule files for the task:
+- coding rules
+- docblock rules
+- comment rules
+- testing rules
+- auth provider rules when auth is affected
+- verification rules before closing the task

--- a/README.md
+++ b/README.md
@@ -92,21 +92,21 @@ You can later switch to any paid provider (OpenAI/Gemini/...) without redesignin
              ▼
 ┌──────────────────────────┐
 │        NGINX Proxy       │
-└───────┬────────┬─────────┘
-        │        │
-        │        │
-        ▼        ▼
+└───────┬─────────────────┬┘
+        │                 │
+        │                 │
+        ▼                 ▼
 ┌──────────────┐  ┌──────────────────────┐
-│ services/n8n │  │ services/python      │
-│ Workflows    │  │ Utility APIs         │
+│ services/n8n │  │    services/python   │
+│  Workflows   │  │     Utility APIs     │
 └──────┬───────┘  └──────────┬───────────┘
        │                     │
-       ├──────────────┐      │
-       ▼              ▼      ▼
-┌──────────────┐  ┌───────────────┐
-│ Ollama       │  │ LibreTranslate│
-│ Local LLM    │  │ Translation   │
-└──────────────┘  └───────────────┘
+       ├────────────────┐    │
+       ▼                ▼    ▼
+┌──────────────┐  ┌────────────────┐
+│   Ollama     │  │ LibreTranslate │
+│ Local LLM    │  │  Translation   │
+└──────────────┘  └────────────────┘
 
 ┌──────────────────────────┐
 │       PostgreSQL         │
@@ -176,10 +176,10 @@ LARAVEL-N8N-AUTOMATION/
 
 ### Internal docs
 
-- **Architecture Overview**: `docs/ARCHITECTURE.md`
-- **Folder Organization**: `docs/FOLDER-ORGANIZATION.md`
-- **Integration Flow**: `docs/INTEGRATION-FLOW.md`
-- **Local AI Runbook**: `docs/LOCAL-AI-RUNBOOK.md`
+- **Architecture Overview**: `docs/architecture.md`
+- **Folder Organization**: `docs/folder-organization.md`
+- **Integration Flow**: `docs/integration-flow.md`
+- **Local AI Runbook**: `docs/local-ai-runbook.md`
 - **AI Prompt Pack**: `ai-local/README.md`
 
 ---

--- a/apps/laravel/README.md
+++ b/apps/laravel/README.md
@@ -43,6 +43,6 @@ Folder `apps/laravel/` trong repo nay dong vai tro:
 
 ## Lien ket tai lieu
 
-- `../docs/ARCHITECTURE.md`
-- `../docs/INTEGRATION-FLOW.md`
+- `../docs/architecture.md`
+- `../docs/integration-flow.md`
 - `../ai-local/README.md`

--- a/apps/laravel/resources/js/spa/features/i18n/messages.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages.js
@@ -502,7 +502,7 @@ export const messages = {
             logoutEyebrow: 'Đăng xuất',
             logoutTitle: 'Đăng xuất khỏi khu quản trị?',
             logoutText:
-                'Phiên làm việc hiện tại sẽ kết thúc và anh sẽ quay lại màn hình đăng nhập.',
+                'Phiên làm việc hiện tại sẽ kết thúc và bạn sẽ quay lại màn hình đăng nhập.',
         },
         footer: {
             text: 'Không gian React tập trung cho market tracking, workflow nội dung và vận hành nội bộ.',
@@ -526,7 +526,7 @@ export const messages = {
             loginError: 'Không đăng nhập được với tài khoản này.',
             forgotPasswordLink: 'Quên mật khẩu?',
             forgotPasswordTitle: 'Quên mật khẩu?',
-            forgotPasswordText: 'Nhập email của anh và hệ thống sẽ gửi liên kết đặt lại mật khẩu.',
+            forgotPasswordText: 'Nhập email và hệ thống sẽ gửi liên kết đặt lại mật khẩu.',
             forgotPasswordSubmit: 'Gửi liên kết đặt lại',
             forgotPasswordSending: 'Đang gửi...',
             forgotPasswordSent: 'Đã gửi liên kết đặt lại mật khẩu.',
@@ -536,15 +536,15 @@ export const messages = {
             forgotPasswordShowcaseText:
                 'Dùng luồng đặt lại qua email để xác minh chủ tài khoản và đặt mật khẩu mới an toàn.',
             resetPasswordTitle: 'Đặt lại mật khẩu',
-            resetPasswordText: 'Thiết lập mật khẩu mới cho tài khoản của anh.',
+            resetPasswordText: 'Thiết lập mật khẩu mới cho tài khoản của bạn.',
             resetPasswordSubmit: 'Cập nhật mật khẩu',
             resetPasswordSubmitting: 'Đang cập nhật...',
             resetPasswordError: 'Không thể đặt lại mật khẩu với liên kết này.',
-            resetPasswordSuccess: 'Đã cập nhật mật khẩu thành công. Bây giờ anh có thể đăng nhập.',
+            resetPasswordSuccess: 'Đã cập nhật mật khẩu thành công. Bây giờ bạn có thể đăng nhập.',
             resetPasswordEyebrow: 'Mật khẩu mới',
             resetPasswordShowcaseTitle: 'Đặt mật khẩu mới và quay lại OPAS.',
             resetPasswordShowcaseText:
-                'Hãy chọn một mật khẩu mạnh, dễ nhớ với anh và dùng nó cho những lần đăng nhập sau.',
+                'Hãy chọn một mật khẩu mạnh, dễ nhớ và dùng nó cho những lần đăng nhập sau.',
             providersLoading: 'Đang tải phương thức đăng nhập...',
             noProvidersAvailable: 'Hiện chưa có phương thức đăng nhập nào khả dụng.',
             registrationUnavailable: 'Hiện chưa thể đăng ký tài khoản mới.',
@@ -566,7 +566,7 @@ export const messages = {
             loginShowcaseTitle:
                 'Đăng nhập để quay lại không gian OPAS và tiếp tục các luồng theo dõi, nội dung, và automation đang vận hành.',
             loginShowcaseText:
-                'Đây là lối vào dành cho những phần việc cần tài khoản trong OPAS. Khi đăng nhập xong, anh có thể tiếp tục theo dõi dữ liệu, quản lý đầu vào nội dung và mở các khu automation trong cùng một không gian làm việc.',
+                'Đây là lối vào dành cho những phần việc cần tài khoản trong OPAS. Khi đăng nhập xong, bạn có thể tiếp tục theo dõi dữ liệu, quản lý đầu vào nội dung và mở các khu automation trong cùng một không gian làm việc.',
             registerTitle: 'Đăng ký',
             registerText: 'Tạo tài khoản mới để bắt đầu dùng OPAS theo vai trò thành viên.',
             registerSubmit: 'Tạo tài khoản',
@@ -594,7 +594,7 @@ export const messages = {
             registerShowcaseTitle:
                 'Tạo tài khoản để bắt đầu dùng OPAS theo đúng luồng vận hành của hệ thống, từ theo dõi dữ liệu đến quản lý đầu vào và mở các khu automation.',
             registerShowcaseText:
-                'Tài khoản mới giúp anh đi vào phần thao tác cá nhân của hệ thống một cách gọn gàng hơn. Khi cần thêm quyền hoặc thêm khả năng sử dụng, vai trò có thể được mở rộng tiếp theo đúng cách vận hành thực tế.',
+                'Tài khoản mới giúp bạn đi vào phần thao tác cá nhân của hệ thống một cách gọn gàng hơn. Khi cần thêm quyền hoặc thêm khả năng sử dụng, vai trò có thể được mở rộng tiếp theo đúng cách vận hành thực tế.',
             email: 'Email',
             password: 'Mật khẩu',
             confirmPassword: 'Xác nhận mật khẩu',
@@ -622,7 +622,7 @@ export const messages = {
             editSecret: 'Thay secret mới',
             cancelSecretEdit: 'Giữ secret hiện tại',
             secretMaskedHint:
-                'Secret hiện tại vẫn được lưu an toàn ở backend và không thể hiện lại dưới dạng chữ thường. Chỉ nhập giá trị mới khi anh muốn thay secret.',
+                'Secret hiện tại vẫn được lưu an toàn ở backend và không thể hiện lại dưới dạng chữ thường. Chỉ nhập giá trị mới khi bạn muốn thay secret.',
             readyToSave: 'Cấu hình hiện tại hợp lệ và có thể lưu.',
             noChangesToSave:
                 'Chưa có thay đổi nào để lưu. Hãy sửa dữ liệu hoặc đổi trạng thái trước.',

--- a/apps/laravel/tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php
@@ -72,6 +72,46 @@ class AdminAuthProviderApiControllerTest extends TestCase
     }
 
     /**
+     * Non-admin users must not update provider settings from the admin endpoint.
+     */
+    public function test_non_admin_cannot_update_auth_provider(): void
+    {
+        $member = User::factory()->create([
+            'role' => UserRole::Member,
+        ]);
+
+        $response = $this
+            ->actingAs($member)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'google']), [
+                'enabled' => true,
+            ]);
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * Guests must authenticate before accessing admin provider settings.
+     */
+    public function test_guest_cannot_list_auth_providers(): void
+    {
+        $response = $this->getJson(route('api.admin.auth.providers.index'));
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Guests must authenticate before updating admin provider settings.
+     */
+    public function test_guest_cannot_update_auth_provider(): void
+    {
+        $response = $this->putJson(route('api.admin.auth.providers.update', ['key' => 'google']), [
+            'enabled' => true,
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
      * Admin-only provider endpoints should also send no-store headers because they expose sensitive config metadata.
      */
     public function test_admin_provider_listing_is_not_cacheable(): void
@@ -128,6 +168,99 @@ class AdminAuthProviderApiControllerTest extends TestCase
         $provider = AuthProvider::query()->where('key', 'google')->firstOrFail();
 
         $this->assertSame('google-secret', $provider->secret_config['client_secret']);
+    }
+
+    /**
+     * Email provider policy updates should persist so auth flows can consume them later.
+     */
+    public function test_admin_can_update_email_verification_mode_for_email_provider(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'email']), [
+                'enabled' => true,
+                'display_name' => 'Email and Password',
+                'sort_order' => 10,
+                'visibility' => 'public',
+                'email_verification_mode' => 'optional',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.key', 'email')
+            ->assertJsonPath('data.email_verification_mode', 'optional');
+
+        $this->assertDatabaseHas('auth_providers', [
+            'key' => 'email',
+            'email_verification_mode' => 'optional',
+        ]);
+    }
+
+    /**
+     * Unknown provider keys must return a not found response instead of mutating unrelated state.
+     */
+    public function test_admin_update_returns_not_found_for_unknown_provider(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'unknown-provider']), [
+                'enabled' => true,
+            ]);
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Enabling an OAuth provider without its required configuration must be rejected.
+     */
+    public function test_admin_update_rejects_enabling_provider_without_required_config(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'google']), [
+                'enabled' => true,
+                'visibility' => 'public',
+                'public_config' => [
+                    'client_id' => 'google-client-id',
+                ],
+                'secret_config' => [],
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors([
+                'public_config.redirect_uri',
+                'secret_config.client_secret',
+            ]);
+    }
+
+    /**
+     * Invalid verification policy values must be rejected safely by request validation.
+     */
+    public function test_admin_update_rejects_invalid_email_verification_mode(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'email']), [
+                'email_verification_mode' => 'always',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['email_verification_mode']);
     }
 
     /**

--- a/apps/laravel/tests/Unit/Http/Resources/AdminAuthProviderResourceTest.php
+++ b/apps/laravel/tests/Unit/Http/Resources/AdminAuthProviderResourceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\AdminAuthProviderResource;
+use App\Models\AuthProvider;
+use App\Services\Auth\AuthProviderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Verify admin auth provider resource shaping independently from controller transport.
+ */
+class AdminAuthProviderResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Secret status should expose presence flags without returning plaintext secret values.
+     */
+    public function test_to_array_reports_secret_status_without_exposing_secret_config(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'google')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'google-client-id',
+                'redirect_uri' => 'https://example.com/auth/google/callback',
+            ],
+            'secret_config' => [
+                'client_secret' => 'test-secret',
+            ],
+        ]);
+
+        $resolved = $this->app->make(AuthProviderService::class)->resolve('google');
+
+        $this->assertNotNull($resolved);
+
+        $payload = (new AdminAuthProviderResource($resolved))->toArray(new Request);
+
+        $this->assertSame('google', $payload['key']);
+        $this->assertSame(['client_secret' => true], $payload['secret_status']);
+        $this->assertSame(['client_id', 'redirect_uri'], $payload['required_public_keys']);
+        $this->assertSame(['client_secret'], $payload['required_secret_keys']);
+        $this->assertArrayNotHasKey('secret_config', $payload);
+    }
+
+    /**
+     * Providers without stored secrets should report a false secret status flag.
+     */
+    public function test_to_array_reports_missing_secret_as_false(): void
+    {
+        $resolved = $this->app->make(AuthProviderService::class)->resolve('google');
+
+        $this->assertNotNull($resolved);
+
+        $payload = (new AdminAuthProviderResource($resolved))->toArray(new Request);
+
+        $this->assertSame(['client_secret' => false], $payload['secret_status']);
+    }
+}

--- a/apps/laravel/tests/Unit/Repositories/Auth/AuthProviderRepositoryTest.php
+++ b/apps/laravel/tests/Unit/Repositories/Auth/AuthProviderRepositoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Repositories\Auth;
+
+use App\Models\AuthProvider;
+use App\Repositories\Auth\AuthProviderRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Verify repository-level data access rules for auth providers.
+ */
+class AuthProviderRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Providers should be returned in admin-friendly display order.
+     */
+    public function test_get_ordered_returns_providers_sorted_by_sort_order_then_display_name(): void
+    {
+        AuthProvider::query()->where('key', 'email')->update([
+            'sort_order' => 30,
+            'display_name' => 'Email Z',
+        ]);
+        AuthProvider::query()->where('key', 'google')->update([
+            'sort_order' => 10,
+            'display_name' => 'Google',
+        ]);
+        AuthProvider::query()->where('key', 'facebook')->update([
+            'sort_order' => 20,
+            'display_name' => 'Facebook',
+        ]);
+        AuthProvider::query()->where('key', 'github')->update([
+            'sort_order' => 30,
+            'display_name' => 'GitHub A',
+        ]);
+
+        $providers = $this->app->make(AuthProviderRepository::class)->getOrdered();
+
+        $this->assertSame(
+            ['google', 'facebook', 'email', 'github'],
+            $providers->pluck('key')->all(),
+        );
+    }
+
+    /**
+     * Provider lookup should resolve a persisted row by its stable key.
+     */
+    public function test_find_by_key_returns_matching_provider(): void
+    {
+        $provider = $this->app->make(AuthProviderRepository::class)->findByKey('google');
+
+        $this->assertInstanceOf(AuthProvider::class, $provider);
+        $this->assertSame('google', $provider->key);
+    }
+
+    /**
+     * Repository updates should persist changes and return a fresh encrypted payload.
+     */
+    public function test_update_persists_changes_and_returns_fresh_model(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'google')->firstOrFail();
+
+        $updated = $this->app->make(AuthProviderRepository::class)->update($provider, [
+            'display_name' => 'Google Workspace',
+            'enabled' => true,
+            'secret_config' => [
+                'client_secret' => 'test-secret',
+            ],
+        ]);
+
+        $this->assertSame('Google Workspace', $updated->display_name);
+        $this->assertTrue($updated->enabled);
+        $this->assertSame('test-secret', $updated->secret_config['client_secret']);
+        $this->assertDatabaseHas('auth_providers', [
+            'key' => 'google',
+            'display_name' => 'Google Workspace',
+            'enabled' => true,
+        ]);
+    }
+}

--- a/apps/laravel/tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php
+++ b/apps/laravel/tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php
@@ -61,4 +61,54 @@ class AuthProviderConfigServiceTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Enabled OAuth providers must require the full minimum config set before activation.
+     */
+    public function test_update_rejects_missing_required_config_when_provider_is_enabled(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'google')->firstOrFail();
+
+        try {
+            $this->app->make(AuthProviderConfigService::class)->update($provider, [
+                'enabled' => true,
+                'visibility' => 'public',
+                'public_config' => [
+                    'client_id' => 'google-client-id',
+                ],
+                'secret_config' => [],
+            ]);
+
+            $this->fail('Expected validation exception was not thrown.');
+        } catch (ValidationException $exception) {
+            $errors = $exception->errors();
+
+            $this->assertArrayHasKey('public_config.redirect_uri', $errors);
+            $this->assertArrayHasKey('secret_config.client_secret', $errors);
+        }
+    }
+
+    /**
+     * Removing the last active login provider must be rejected to protect sign-in access.
+     */
+    public function test_update_rejects_disabling_last_active_login_provider(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'email')->firstOrFail();
+
+        AuthProvider::query()->whereIn('key', ['google', 'facebook', 'github'])->update([
+            'enabled' => false,
+        ]);
+
+        try {
+            $this->app->make(AuthProviderConfigService::class)->update($provider, [
+                'enabled' => false,
+            ]);
+
+            $this->fail('Expected validation exception was not thrown.');
+        } catch (ValidationException $exception) {
+            $errors = $exception->errors();
+
+            $this->assertArrayHasKey('enabled', $errors);
+        }
+    }
 }

--- a/apps/laravel/tests/Unit/Services/Auth/AuthProviderServiceTest.php
+++ b/apps/laravel/tests/Unit/Services/Auth/AuthProviderServiceTest.php
@@ -63,4 +63,66 @@ class AuthProviderServiceTest extends TestCase
 
         $this->assertFalse($this->app->make(AuthProviderService::class)->canUse('google'));
     }
+
+    /**
+     * Ready and enabled providers should resolve as usable for the requested capability.
+     */
+    public function test_can_use_returns_true_for_ready_enabled_provider(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'google')->firstOrFail();
+
+        $provider->update([
+            'enabled' => true,
+            'visibility' => 'public',
+            'public_config' => [
+                'client_id' => 'google-client-id',
+                'redirect_uri' => 'https://example.com/auth/google/callback',
+            ],
+            'secret_config' => [
+                'client_secret' => 'test-secret',
+            ],
+        ]);
+
+        $this->assertTrue($this->app->make(AuthProviderService::class)->canUse('google', 'login'));
+    }
+
+    /**
+     * Unknown provider keys should not resolve into a runtime contract.
+     */
+    public function test_resolve_returns_null_for_unknown_provider(): void
+    {
+        $resolved = $this->app->make(AuthProviderService::class)->resolve('unknown-provider');
+
+        $this->assertNull($resolved);
+    }
+
+    /**
+     * Persisted verification policy should be returned directly when the provider defines one.
+     */
+    public function test_email_verification_mode_returns_provider_specific_value(): void
+    {
+        AuthProvider::query()->where('key', 'email')->update([
+            'email_verification_mode' => 'optional',
+        ]);
+
+        $mode = $this->app->make(AuthProviderService::class)->emailVerificationMode('email');
+
+        $this->assertSame('optional', $mode);
+    }
+
+    /**
+     * Email verification should fall back to application config when the provider has no override.
+     */
+    public function test_email_verification_mode_falls_back_to_config_default(): void
+    {
+        AuthProvider::query()->where('key', 'email')->update([
+            'email_verification_mode' => null,
+        ]);
+
+        config()->set('opas.auth.email_verification.default_mode', 'disabled');
+
+        $mode = $this->app->make(AuthProviderService::class)->emailVerificationMode('email');
+
+        $this->assertSame('disabled', $mode);
+    }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,17 +1,17 @@
-# Kien Truc Tong The
+# System Architecture
 
-## Muc tieu
+## Goal
 
-Repo nay duoc to chuc theo mo hinh:
+This repository is organized around the following model:
 
-- Laravel = giao dien va diem vao nguoi dung
+- Laravel = user-facing interface and entry point
 - n8n = workflow engine
-- Python services = utility layer va data processing
+- Python services = utility layer and data processing
 - Ollama = local LLM runtime
 - LibreTranslate = local translation layer
-- PostgreSQL = du lieu dung chung
+- PostgreSQL = shared data store
 
-## So do logic
+## Logical Diagram
 
 ```text
 User
@@ -28,36 +28,36 @@ Laravel UI/API
              \----> Ollama
 ```
 
-## Nguyen tac ket noi
+## Integration Principles
 
-- Laravel khong nen goi truc tiep qua nhieu node AI.
-- n8n nen giu vai tro orchestration cho cac pipeline dai.
-- Python services nen giu cac tac vu:
+- Laravel should not call too many AI nodes directly.
+- n8n should keep the orchestration role for long pipelines.
+- Python services should own tasks such as:
   - parsing
   - scraping
   - preprocessing
   - validation
-  - adapter cho external APIs
-- Ollama nen duoc goi qua prompt co cau truc va output JSON khi co the.
-- LibreTranslate nen dung cho translation layer, khong gan logic nghiep vu vao service nay.
+  - external API adapter logic
+- Ollama should be called through structured prompts and JSON output whenever possible.
+- LibreTranslate should stay in the translation layer and should not absorb business logic.
 
-## Trang thai source hien tai
+## Current Source Status
 
-- Laravel da co mot service client cho Python: `App\Services\Python\PythonService`
-- Route Laravel hien chu yeu phuc vu:
+- Laravel already has a Python client service: `App\Services\Python\PythonService`
+- Laravel routes currently focus mainly on:
   - coin
   - stock
   - video automation
-- Python service hien dang expose rat it route tong hop; can bo sung them route nghiep vu neu muon Laravel goi on dinh.
-- n8n da co nhieu workflow JSON nhung chua co tai lieu mapping use-case ro rang.
+- The Python service currently exposes only a small set of aggregate routes; more business-oriented routes should be added if Laravel is expected to depend on it more heavily.
+- n8n already contains multiple workflow JSON files, but the use-case mapping is not yet documented clearly.
 
-## Dinh huong tiep theo
+## Recommended Next Direction
 
-Nen chia use-case thanh 3 lop:
+Use cases should be split into three layers:
 
 1. `interactive`
-   Laravel goi truc tiep Python service hoac n8n webhook va cho ket qua ngay.
+   Laravel calls a Python service or n8n webhook directly and waits for an immediate response.
 2. `workflow`
-   n8n xu ly pipeline dai, co trang thai job.
+   n8n handles long-running pipelines and job state.
 3. `ai-assisted`
-   n8n/Python goi Ollama va LibreTranslate, tra ve ket qua da chuan hoa.
+   n8n or Python calls Ollama and LibreTranslate, then returns normalized output.

--- a/docs/CODEGEN-RULES.md
+++ b/docs/CODEGEN-RULES.md
@@ -1,92 +1,31 @@
-# Codegen Rules
+# Codegen Rules Index
 
-## Purpose
+Use this file as the entry point for implementation rules when a task touches `apps/laravel`.
 
-Use this file as the default engineering rulebook for changes in this repository.
+Read only the sections that match the task at hand:
 
-When a task touches `apps/laravel`, read this document first and follow it unless the user explicitly asks for a different tradeoff.
+- [docs/rules/coding-rules.md](docs/rules/coding-rules.md)
+  Use for general coding style, naming, config handling, layering, database changes, and delivery expectations.
+- [docs/rules/docblock-rules.md](docs/rules/docblock-rules.md)
+  Use for PHP docblock requirements in `app/`.
+- [docs/rules/comment-rules.md](docs/rules/comment-rules.md)
+  Use when adding or reviewing code comments.
+- [docs/rules/testing-rules.md](docs/rules/testing-rules.md)
+  Use when adding or updating tests, including folder structure and coverage expectations.
+- [docs/rules/auth-provider-rules.md](docs/rules/auth-provider-rules.md)
+  Use when changing authentication providers, OAuth configuration, verification policy, or provider-facing admin screens.
+- [docs/rules/verification-rules.md](docs/rules/verification-rules.md)
+  Use before closing a Laravel task to run formatting and static analysis consistently.
 
-## Config And Secrets
+Minimum reading path by task type:
 
-- Never hardcode secrets, API keys, client secrets, passwords, or environment-specific credentials in PHP, JS, migrations, seeders, or tests.
-- Put environment-specific values in `apps/laravel/.env` and document required keys in `apps/laravel/.env.example`.
-- Put runtime access to env values behind Laravel config files such as `config/opas.php`, `config/services.php`, `config/queue.php`, or `config/mail.php`.
-- Application code should read from `config()` instead of calling `env()` directly outside config files.
-- Do not hardcode provider URLs, callback base URLs, API base URLs, or OAuth endpoints in app code. Put them in config and source them from env when they may vary by environment or provider version.
-- DB-stored provider credentials belong in the database and must be encrypted at rest when sensitive.
-- Frontend code must never receive secrets. Expose only safe metadata.
-
-## Laravel Layering
-
-- Keep controllers thin.
-- Controllers should validate input, call services, and return resources or responses.
-- Business logic belongs in services.
-- Database query orchestration belongs in repositories.
-- Eloquent models should stay small and focused on relationships, casts, accessors, and narrowly scoped helpers.
-- If a feature touches multiple aggregates or has branching rules, create or extend a service instead of growing controller logic.
-- If a service starts accumulating raw query details, move those queries into a repository.
-
-## Database Rules
-
-- Every schema change must go through a migration.
-- Do not bury schema creation or schema mutation in services or controllers.
-- When a feature adds persistence behavior, decide whether it belongs in an existing repository or needs a new repository.
-- Sensitive tokens, secrets, and long-lived credentials must be encrypted using Laravel casts or equivalent backend protection.
-- Prefer explicit column names and indexes for lookup-heavy auth tables.
-
-## Auth Provider Rules
-
-- Provider lists must resolve dynamically from backend state, not from hardcoded frontend arrays.
-- Provider readiness checks belong in auth provider drivers or services, not in controllers.
-- Provider-specific OAuth logic should live in provider drivers or dedicated auth services.
-- Email/password flow, OAuth flow, verification flow, and provider config flow should stay separated by responsibility.
-- Callback URLs exposed to admins or frontend should be backend-generated.
-- Secret provider config must not be returned in plaintext responses.
-
-## Function And Class Structure
-
-- If a function becomes long or handles more than one concern, split it into smaller private methods.
-- Prefer small methods with descriptive names over a single large method.
-- Services should expose a small public API and hide branching logic in private methods.
-- When a class grows by feature area, split by responsibility rather than adding unrelated helper methods.
-
-## Docblock Rules
-
-- Every public and protected PHP method in `app/` must have a docblock with a one-line summary.
-- Private PHP methods should also have a docblock when they contain branching, data shaping, persistence rules, auth rules, or non-trivial formatting logic.
-- Every documented method must include `@return`, even when the native PHP return type is obvious.
-- Every documented method with parameters must include `@param` for each parameter.
-- Array-shaped payloads must declare their array shape in `@param` or `@return` whenever practical.
-- Keep docblocks concise and factual.
-- Avoid docblocks that restate the function name without adding meaning.
-
-## Frontend Rules
-
-- Frontend should consume backend contracts rather than reconstruct backend rules locally.
-- Keep API access inside shared API helpers or feature context layers.
-- Do not duplicate auth or readiness logic in multiple screens if a shared hook or context can own it.
-- Never store backend secrets or privileged config in SPA state.
-
-## Testing Rules
-
-- Add or update feature tests for user-facing behavior changes.
-- Add or update unit tests for service-level branching or validation rules.
-- For auth changes, cover success path, denial path, and invalid configuration path where relevant.
-
-## Static Analysis And Formatting
-
-- Before closing a Laravel code task, run `./vendor/bin/pint` on changed PHP files.
-- Before closing a Laravel code task, run `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon` on changed PHP paths or the narrowest relevant scope.
-- Do not ignore formatter or static-analysis failures without documenting the reason to the user.
-
-## Delivery Checklist
-
-- Required env keys are present in `apps/laravel/.env.example`.
-- Runtime config reads from `config()`, not direct `env()` calls in app code.
-- Controllers remain thin.
-- Database logic is in repositories or models only where appropriate.
-- Sensitive values are not exposed to frontend or logs.
-- New and modified PHP methods follow the docblock rules above, including explicit `@param` and `@return`.
-- Tests cover the new behavior.
-- `pint` has been run for changed PHP files.
-- `phpstan` has been run for the changed Laravel scope.
+- Laravel feature work:
+  - `coding-rules.md`
+  - `docblock-rules.md`
+  - `testing-rules.md`
+  - `verification-rules.md`
+- Auth provider or login flow work:
+  - all files above
+  - `auth-provider-rules.md`
+- Documentation-only work:
+  - read only the relevant docs file being edited unless `AGENTS.md` says otherwise

--- a/docs/FOLDER-ORGANIZATION.md
+++ b/docs/FOLDER-ORGANIZATION.md
@@ -1,55 +1,55 @@
-# To Chuc Folder
+# Folder Organization
 
-## Nguyen tac
+## Principles
 
-- Khong doi vi tri folder runtime dang duoc `docker-compose.yml` mount.
-- Them folder tai lieu va prompt de quan ly luong van hanh ro rang.
-- Moi service tu quan ly code cua no; tai lieu chung dat o root.
+- Do not move runtime folders that are already mounted by `docker-compose.yml`.
+- Add documentation and prompt folders so operational flows stay explicit and maintainable.
+- Each service should own its own runtime code, while shared documentation stays at the repository root.
 
-## Cau truc nen giu
+## Recommended Structure
 
 ```text
-apps/laravel/        Web app va API gateway
+apps/laravel/        Web app and API gateway
 services/python/     FastAPI services
-services/n8n/        Workflow, node, credential data
+services/n8n/        Workflow, node, and credential data
 services/libretranslate/
-  Dockerfile + models ArgosTranslate
+  Dockerfile + ArgosTranslate models
 docker/              Persistent runtime data
 nginx/               Reverse proxy
 scripts/             Utility scripts
-docs/                Kien truc, runbook, tich hop
-ai-local/            Prompt va quy uoc dieu khien LLM local
+docs/                Architecture, runbooks, and integration guides
+ai-local/            Prompts and local LLM control conventions
 ```
 
-## Y nghia folder moi
+## Meaning Of The Added Folders
 
 ### `docs/`
 
-Tai lieu cho nguoi van hanh va nguoi phat trien:
+Documentation for operators and developers:
 
-- kien truc
-- luong tich hop
-- quy uoc folder
-- runbook AI local
+- architecture
+- integration flow
+- folder conventions
+- local AI runbook
 
 ### `ai-local/`
 
-Bo prompt va quy tac de goi AI local nhat quan:
+Prompt pack and control rules for consistent local AI usage:
 
-- prompt cho model viet nhap
-- prompt cho model review
-- prompt cho orchestration
-- prompt cho post-edit translation
+- drafting prompts
+- review prompts
+- orchestration prompts
+- translation post-edit prompts
 
-## Thu tu uu tien khi them file moi
+## Priority Order When Adding New Files
 
-1. File chay runtime dat trong service tuong ung.
-2. File prompt hoac instruction dat trong `ai-local/`.
-3. File mo ta luong hoac quy uoc dat trong `docs/`.
-4. Script phu tro dat trong `scripts/`.
+1. Runtime files should live inside the relevant service.
+2. Prompt or instruction files should live in `ai-local/`.
+3. Flow descriptions or conventions should live in `docs/`.
+4. Support scripts should live in `scripts/`.
 
-## Khong nen lam
+## What To Avoid
 
-- Khong dat prompt AI lung tung trong `n8n/workflows/` hoac `laravel/resources/`.
-- Khong dat tai lieu van hanh trong README cua tung framework mac dinh.
-- Khong doi them folder runtime nua neu chua sua toan bo volume mount va script lien quan.
+- Do not scatter AI prompts across `n8n/workflows/` or `laravel/resources/`.
+- Do not put operational documentation only inside framework-specific default READMEs.
+- Do not add more runtime folders unless all related volume mounts and scripts are updated together.

--- a/docs/INTEGRATION-FLOW.md
+++ b/docs/INTEGRATION-FLOW.md
@@ -1,84 +1,84 @@
-# Luong Tich Hop
+# Integration Flow
 
 ## 1. Laravel -> n8n
 
-Dung khi:
+Use this when:
 
-- can trigger workflow dai
-- can retry
-- can log tung buoc
-- can ket hop AI, translation, upload, scheduling
+- you need to trigger long-running workflows
+- you need retries
+- you need step-by-step logging
+- you need to combine AI, translation, uploads, or scheduling
 
-De nghi:
+Recommended approach:
 
-- Laravel goi vao webhook cua n8n
-- Laravel luu `job_id`, `workflow_name`, `payload_hash`, `status`
-- n8n tra ve ket qua ngan hoac callback lai Laravel
+- Laravel calls an n8n webhook
+- Laravel stores `job_id`, `workflow_name`, `payload_hash`, and `status`
+- n8n returns a short result immediately or calls Laravel back later
 
 ## 2. Laravel -> Python Services
 
-Dung khi:
+Use this when:
 
-- can response nhanh
-- can mot utility service don le
-- can parsing/scraping/preprocess
+- you need a fast response
+- you need a focused utility service
+- you need parsing, scraping, or preprocessing
 
-Hien tai:
+Current status:
 
-- `apps/laravel/app/Services/Python/PythonService.php` dang la client co ban
-- nen mo rong thanh service theo tung domain thay vi mot class chung cho moi use-case
+- `apps/laravel/app/Services/Python/PythonService.php` is currently a basic client
+- it should evolve into domain-specific services instead of one generic class for every use case
 
 ## 3. n8n -> Ollama
 
-Dung khi:
+Use this when:
 
-- viet nhap bai
-- rewrite
-- review output
-- generate structured JSON
+- drafting content
+- rewriting
+- reviewing output
+- generating structured JSON
 
-Quy uoc de nghi:
+Recommended conventions:
 
 - `qwen2.5:7b`: writer / planner
 - `mistral:7b`: critic / reviewer
-- moi workflow luu prompt goc trong `ai-local/agents/*.md`
-- n8n chi tham chieu prompt, khong nen viet prompt dai truc tiep trong node neu co the tranh
+- each workflow should store its source prompt in `ai-local/agents/*.md`
+- n8n should reference prompts instead of embedding long prompts directly in nodes whenever possible
 
 ## 4. n8n -> LibreTranslate
 
-Dung khi:
+Use this when:
 
-- dich nhap
-- tao phien ban ngon ngu thu hai
-- tien xu ly hoac hau xu ly noi dung AI
+- translating drafts
+- generating a second language version
+- preprocessing or postprocessing AI content
 
-De nghi:
+Recommended approach:
 
-- Dich thuan bang LibreTranslate
-- Neu can do truot, chay them mot buoc AI post-edit bang Ollama
+- perform direct translation with LibreTranslate
+- if quality slips, add one AI post-edit step with Ollama
 
 ## 5. Python Services -> Ollama
 
-Dung khi:
+Use this when:
 
-- can xu ly AI co logic lap trinh phuc tap
-- can validate output JSON
-- can chunking, retry, fallback
+- AI processing needs more programming control
+- JSON output must be validated
+- you need chunking, retries, or fallback logic
 
-Neu lam theo huong nay, Python service nen dong vai tro adapter:
+In that case, the Python service should act as an adapter:
 
-- nhan payload tu Laravel hoac n8n
-- goi Ollama
-- validate schema
-- tra ket qua sach
+- receive payloads from Laravel or n8n
+- call Ollama
+- validate the schema
+- return normalized output
 
-## Luong goi y cho bai toan cua ban
+## Suggested Flow For This Stack
 
-1. User nhap yeu cau tai Laravel
-2. Laravel trigger n8n workflow
-3. n8n goi Python service de lay/lam sach du lieu
-4. n8n goi Qwen de tao draft
-5. n8n goi LibreTranslate neu can da ngon ngu
-6. n8n goi Mistral de review hoac post-edit
-7. n8n tra ket qua ve Laravel
-8. Laravel hien thi, luu log va lich su
+1. The user submits a request in Laravel.
+2. Laravel triggers an n8n workflow.
+3. n8n calls a Python service to fetch or clean data.
+4. n8n calls Qwen to generate a draft.
+5. n8n calls LibreTranslate if another language version is needed.
+6. n8n calls Mistral to review or post-edit the result.
+7. n8n returns the result to Laravel.
+8. Laravel displays the result and stores logs and history.

--- a/docs/LOCAL-AI-RUNBOOK.md
+++ b/docs/LOCAL-AI-RUNBOOK.md
@@ -1,71 +1,71 @@
-# Runbook AI Local
+# Local AI Runbook
 
-## Thanh phan
+## Components
 
 - Ollama container: `ollama`
 - Writer model: `qwen2.5:7b`
 - Reviewer model: `mistral:7b`
 - Translation service: `libretranslate`
 
-## Lenh can nho
+## Commands To Remember
 
-Khoi dong stack:
+Start the stack:
 
 ```bash
 docker compose up -d
 ```
 
-Nap model Ollama:
+Pull Ollama models:
 
 ```bash
 bash scripts/ollama-pull-models.sh
 ```
 
-Kiem tra model:
+Check installed models:
 
 ```bash
 docker exec -it ollama ollama list
 ```
 
-## Quy uoc su dung model
+## Model Usage Conventions
 
 ### `qwen2.5:7b`
 
-Dung cho:
+Use for:
 
-- viet nhap
-- tong hop
-- phac thao cau truc
-- sinh JSON ke hoach
+- drafting
+- synthesis
+- structure planning
+- JSON plan generation
 
 ### `mistral:7b`
 
-Dung cho:
+Use for:
 
 - review
-- phat hien loi logic
-- rut gon
-- chuan hoa output
+- logic issue detection
+- compression
+- output normalization
 
-## Quy uoc prompt
+## Prompt Conventions
 
-- Moi prompt goc dat trong `ai-local/agents/`.
-- Prompt phai ghi ro:
-  - vai tro
+- Store each source prompt in `ai-local/agents/`.
+- Every prompt should clearly define:
+  - role
   - input
-  - rang buoc
-  - dinh dang output
-- Uu tien output JSON khi workflow can xu ly tiep.
+  - constraints
+  - output format
+- Prefer JSON output when the workflow needs downstream processing.
 
-## Cach dung trong n8n
+## How To Use In n8n
 
-1. Tao node HTTP request toi `http://ollama:11434/api/chat`
-2. Chon model theo file prompt
-3. Nap noi dung system/user tu file `.md` trong repo
-4. Bat buoc validate output truoc khi ghi DB hoac publish
+1. Create an HTTP Request node to `http://ollama:11434/api/chat`.
+2. Choose the model based on the prompt file.
+3. Load the system and user content from `.md` files in the repository.
+4. Always validate the output before writing to the database or publishing.
 
-## Cach dung trong Laravel/Python
+## How To Use In Laravel/Python
 
-- Laravel nen goi n8n cho workflow dai.
-- Python service nen goi Ollama khi can validate, retry, chunking.
-- Khong nen de prompt nghiep vu phan tan trong source ma khong co file tai lieu goc.
+- Laravel should call n8n for long-running workflows.
+- Python services should call Ollama when validation, retry logic, or chunking is needed.
+- Do not spread business prompts across source code without a canonical documentation file.

--- a/docs/rules/auth-provider-rules.md
+++ b/docs/rules/auth-provider-rules.md
@@ -1,0 +1,28 @@
+# Auth Provider Rules
+
+## Purpose
+
+Apply these rules whenever a task touches login methods, OAuth providers, provider admin screens, or verification policy.
+
+## Provider Resolution Rules
+
+- Provider lists must resolve dynamically from backend state, not from hardcoded frontend arrays.
+- Provider readiness checks belong in auth provider drivers or services, not in controllers.
+- Provider-specific OAuth logic should live in provider drivers or dedicated auth services.
+- Email/password flow, OAuth flow, verification flow, and provider config flow should stay separated by responsibility.
+
+## Config And Exposure Rules
+
+- Callback URLs exposed to admins or frontend should be backend-generated.
+- Secret provider config must not be returned in plaintext responses.
+- Sensitive provider credentials must stay encrypted at rest.
+- Frontend should receive only safe metadata and readiness state.
+
+## Admin Management Rules
+
+- Admin provider settings endpoints must be restricted to authorized admins.
+- Invalid provider configuration must be rejected before a provider can become active.
+- If the system has a baseline sign-in method, protect it with an explicit business rule and corresponding tests.
+- Public login screens should show only providers that are active, ready, and intended for public visibility.
+- Provider enablement rules should be enforced on the backend even if the frontend also prevents unsafe actions.
+- Provider readiness and provider visibility are separate concerns and must not be conflated.

--- a/docs/rules/coding-rules.md
+++ b/docs/rules/coding-rules.md
@@ -1,0 +1,94 @@
+# Coding Rules
+
+## Purpose
+
+Use these rules as the default engineering baseline for Laravel application code.
+
+## Config And Secrets
+
+- Never hardcode secrets, API keys, client secrets, passwords, or environment-specific credentials in PHP, JS, migrations, seeders, or tests.
+- Put environment-specific values in `apps/laravel/.env` and document required keys in `apps/laravel/.env.example`.
+- Put runtime access to env values behind Laravel config files such as `config/opas.php`, `config/services.php`, `config/queue.php`, or `config/mail.php`.
+- Application code should read from `config()` instead of calling `env()` directly outside config files.
+- Do not hardcode provider URLs, callback base URLs, API base URLs, or OAuth endpoints in app code. Put them in config and source them from env when they may vary by environment or provider version.
+- DB-stored provider credentials belong in the database and must be encrypted at rest when sensitive.
+- Frontend code must never receive secrets. Expose only safe metadata.
+
+## Laravel Layering
+
+- Keep controllers thin.
+- Controllers should validate input, call services, and return resources or responses.
+- Business logic belongs in services.
+- Database query orchestration belongs in repositories.
+- Eloquent models should stay small and focused on relationships, casts, accessors, and narrowly scoped helpers.
+- If a feature touches multiple aggregates or has branching rules, create or extend a service instead of growing controller logic.
+- If a service starts accumulating raw query details, move those queries into a repository.
+
+## Naming And Readability Rules
+
+- Prefer explicit names over short names unless the scope is trivially small.
+- Method names should describe behavior, not implementation steps.
+- Variable names should reflect domain meaning, not temporary mechanics such as `data`, `result`, or `item`, unless the scope is tiny and obvious.
+- Avoid boolean names that hide meaning. Prefer `isReady`, `hasStoredSecret`, or `requiresVerification` over generic names like `flag` or `status`.
+- Keep nesting shallow. Prefer guard clauses and early returns over deeply nested conditionals.
+- If a method needs comments to explain each branch, the method likely needs to be split.
+
+## Validation And Error Handling Rules
+
+- Validate external input at the boundary layer closest to entry, usually a request object or dedicated validator.
+- Treat request validation and business-rule validation as separate concerns.
+- Use request rules for shape and primitive constraints.
+- Use services for cross-field, persistence-aware, or domain-specific validation.
+- Return safe, stable error responses. Do not leak secrets, stack traces, or internal infrastructure details.
+- Prefer explicit failure paths over silent fallback unless the fallback is an intentional product rule.
+
+## Service Rules
+
+- Services should orchestrate business rules, not behave like generic helper bags.
+- A service should expose a small public API aligned to a domain capability.
+- Hide branch-heavy logic in private methods with names that express the rule being applied.
+- Do not let services read directly from superglobals, raw requests, or frontend-specific state.
+
+## Repository Rules
+
+- Repositories should own query intent, ordering rules, and lookup constraints that matter to the domain.
+- Repositories should not absorb unrelated business branching.
+- If a query is reused across services or controllers, prefer moving it to a repository method with a stable name.
+- If a repository method returns a refreshed model after persistence, make that behavior explicit and consistent.
+
+## Resource And Response Rules
+
+- Resources should shape transport contracts, not decide business rules.
+- Keep secret filtering, metadata shaping, and field exposure explicit in resources.
+- Do not return plaintext secrets, privileged config, or debug-only fields from resources.
+- Keep API contracts predictable. Avoid returning the same concept under multiple names.
+
+## Database Rules
+
+- Every schema change must go through a migration.
+- Do not bury schema creation or schema mutation in services or controllers.
+- When a feature adds persistence behavior, decide whether it belongs in an existing repository or needs a new repository.
+- Sensitive tokens, secrets, and long-lived credentials must be encrypted using Laravel casts or equivalent backend protection.
+- Prefer explicit column names and indexes for lookup-heavy auth tables.
+
+## Function And Class Structure
+
+- If a function becomes long or handles more than one concern, split it into smaller private methods.
+- Prefer small methods with descriptive names over a single large method.
+- Services should expose a small public API and hide branching logic in private methods.
+- When a class grows by feature area, split by responsibility rather than adding unrelated helper methods.
+
+## Frontend Rules
+
+- Frontend should consume backend contracts rather than reconstruct backend rules locally.
+- Keep API access inside shared API helpers or feature context layers.
+- Do not duplicate auth or readiness logic in multiple screens if a shared hook or context can own it.
+- Never store backend secrets or privileged config in SPA state.
+
+## Delivery Checklist
+
+- Required env keys are present in `apps/laravel/.env.example`.
+- Runtime config reads from `config()`, not direct `env()` calls in app code.
+- Controllers remain thin.
+- Database logic is in repositories or models only where appropriate.
+- Sensitive values are not exposed to frontend or logs.

--- a/docs/rules/comment-rules.md
+++ b/docs/rules/comment-rules.md
@@ -1,0 +1,33 @@
+# Comment Rules
+
+## Purpose
+
+Comments should make code easier to maintain, not compensate for weak naming or poor structure.
+
+## When To Add Comments
+
+- Add a comment when a block enforces a non-obvious business rule.
+- Add a comment when a block protects a security, auth, or data-integrity constraint.
+- Add a comment when the code performs non-trivial normalization, formatting, or branching that would otherwise cost time to re-derive.
+- Add a short section comment when a method has a necessary but dense block that cannot be simplified further without making the code worse.
+
+## When Not To Add Comments
+
+- Do not comment obvious assignments, conditionals, or framework boilerplate.
+- Do not narrate what the code literally says line by line.
+- Do not use comments to excuse a large method that should instead be split.
+- Do not duplicate information already made clear by method names, variable names, or types.
+
+## Style Rules
+
+- Keep comments short, direct, and factual.
+- Prefer explaining intent or constraint over mechanics.
+- Use complete phrases or short sentences.
+- Update or delete comments when the code changes. Stale comments are bugs.
+- Keep comment tone neutral and technical. Avoid conversational or speculative phrasing.
+- If a comment describes a system safety rule, phrase it as a rule, not as a guess.
+
+## Preferred Pattern
+
+- First improve naming and structure.
+- Then add the smallest comment that explains the remaining non-obvious part.

--- a/docs/rules/docblock-rules.md
+++ b/docs/rules/docblock-rules.md
@@ -1,0 +1,35 @@
+# Docblock Rules
+
+## Scope
+
+Apply these rules to PHP code in `apps/laravel/app/`.
+
+## Method Rules
+
+- Every public and protected PHP method in `app/` must have a docblock with a one-line summary.
+- Private PHP methods should also have a docblock when they contain branching, data shaping, persistence rules, auth rules, or non-trivial formatting logic.
+- Every documented method must include `@return`, even when the native PHP return type is obvious.
+- Every documented method with parameters must include `@param` for each parameter.
+- Array-shaped payloads must declare their array shape in `@param` or `@return` whenever practical.
+
+## Class-Level Rules
+
+- Add a class docblock when the class owns a non-obvious domain responsibility or generic type information important to static analysis.
+- Repository classes extending generic bases should declare `@extends` types explicitly.
+- Resource or collection classes should document transformed payload shapes when the shape is non-trivial.
+
+## Quality Rules
+
+- Keep docblocks concise and factual.
+- Avoid docblocks that restate the function name without adding meaning.
+- Document behavior and contract, not implementation noise.
+- If a method exists mainly to enforce a business rule, the summary should make that rule explicit.
+- Prefer imperative clarity over prose. One strong sentence is better than three weak ones.
+- Keep terminology consistent with the domain and the API contract.
+
+## Review Checklist
+
+- The summary explains why the method exists.
+- Parameters reflect real runtime expectations.
+- `@return` matches the actual contract.
+- Complex arrays are typed clearly enough for maintenance and static analysis.

--- a/docs/rules/testing-rules.md
+++ b/docs/rules/testing-rules.md
@@ -1,0 +1,70 @@
+# Testing Rules
+
+## Coverage Baseline
+
+- Add or update feature tests for user-facing behavior changes.
+- Add or update unit tests for service-level branching or validation rules.
+- For auth changes, cover success path, denial path, and invalid configuration path where relevant.
+- Every bug fix should add or update a regression test that fails without the fix.
+
+## Test Design Rules
+
+- Prefer one assertion theme per test.
+- Split large scenario tests into smaller tests when they verify different rules.
+- Name tests from the business rule outward.
+- Tests must describe system behavior, not implementation trivia.
+- Assert observable contract first and internal state second.
+- Keep fixture data minimal and explicit.
+- Avoid hardcoded environment-specific URLs, secrets, and credentials in tests.
+- Prefer representative fake values such as `example.com`, `test-secret`, and route-generated callback URLs.
+- Keep tests deterministic:
+  - fake notifications, queues, mail, and HTTP where applicable
+  - avoid time-sensitive assertions unless the behavior is explicitly time-based
+  - avoid external network or third-party dependency calls
+- Prefer asserting exact business-relevant fields over broad array comparisons.
+- Add positive-path tests for valid behavior and rejection-path tests for invalid or forbidden behavior when both matter to the rule.
+- Avoid over-mocking first-party application code. Prefer real service wiring unless the test is specifically about isolation.
+
+## Admin Configuration Coverage
+
+- For admin-managed configuration features, cover at minimum:
+  - authorized success path
+  - unauthorized or forbidden access path
+  - invalid payload rejection
+  - persistence or state transition result
+  - public contract impact when the setting affects end-user behavior
+
+## Auth Provider Coverage
+
+- For auth provider changes, cover at minimum:
+  - provider listing visibility rules
+  - readiness or incomplete-config rules
+  - secret persistence without plaintext exposure
+  - provider-specific verification policy behavior
+  - baseline sign-in safety rules that prevent total lockout
+- When a feature returns sensitive metadata, add an explicit assertion that secret values are absent from responses.
+- When a setting changes downstream auth behavior, add at least one test at the consumer boundary, not only at the admin update endpoint.
+- When validating structured arrays, assert the smallest meaningful error path such as `public_config.redirect_uri`.
+- When a business rule protects system safety, add both a positive test and a negative regression test whenever practical.
+
+## Test Structure Rules
+
+- Organize tests by the application layer that owns the behavior:
+  - `tests/Feature/Controllers/...` for route, middleware, request validation, response contract, and end-to-end persistence checks
+  - `tests/Unit/Services/...` for service branching, orchestration rules, fallback logic, and validation exceptions
+  - `tests/Unit/Repositories/...` for query ordering, lookup behavior, persistence refresh behavior, and repository-specific data access rules
+  - `tests/Unit/Http/Resources/...` only when resource transformation contains meaningful branching or data shaping worth isolating
+- Do not create controller unit tests. Controller behavior should be covered through HTTP feature tests.
+- Do not add repository tests by default for trivial pass-through CRUD. Add them when the repository owns query ordering, filtering, lookup rules, or refresh semantics that could regress.
+- Request validation is normally covered by feature tests against the endpoint that consumes the request.
+- Resource transformation is normally covered by feature tests against the endpoint that returns the resource.
+- Add a dedicated unit test only when a request, resource, or helper contains branching or data shaping complex enough to justify isolated coverage.
+- Mirror production namespaces in test folders when practical so files are easy to locate and maintain.
+- If a feature touches controller, service, and repository layers with meaningful logic in each layer, prefer adding tests in each corresponding folder instead of forcing all assertions into a single feature test file.
+- If a resource hides or reshapes sensitive fields, prefer a focused resource unit test in addition to controller coverage.
+
+## Maintenance Rules
+
+- Keep test helpers local to the test class unless at least three test classes need the same abstraction.
+- Do not hide important setup in generic helpers when inline setup is clearer for auth or security-sensitive behavior.
+- Before closing a task, verify the narrowest relevant PHPUnit scope locally instead of assuming broader suites will cover the change.

--- a/docs/rules/verification-rules.md
+++ b/docs/rules/verification-rules.md
@@ -1,0 +1,14 @@
+# Verification Rules
+
+## Required Checks Before Closing A Laravel Task
+
+- Run `./vendor/bin/pint` on changed PHP files.
+- Run `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon` on changed PHP paths or the narrowest relevant runtime scope.
+- Run the narrowest relevant PHPUnit scope for the changed behavior.
+
+## Failure Handling
+
+- Do not ignore formatter failures without fixing them or documenting the blocker.
+- Do not ignore static-analysis failures without fixing them or documenting the blocker.
+- If a requested scope cannot be executed, report exactly what could not be run and why.
+- Prefer verifying the smallest relevant scope first, then expand only if the change radius justifies it.


### PR DESCRIPTION
## Summary

This PR finalizes the admin authentication settings screen and hardens the surrounding documentation, rules, and test coverage.

## What Changed

- completed admin auth provider management coverage for the existing settings flow
- added stricter feature and unit tests for:
  - admin provider API access
  - provider update validation
  - provider service behavior
  - provider repository behavior
  - admin provider resource shaping
- added resource and repository test folders to match layer ownership
- split Laravel codegen guidance into focused rule files for:
  - coding
  - docblocks
  - comments
  - testing
  - auth providers
  - verification
- updated `AGENTS.md` to point to the new rule index
- standardized docs naming and converted operational docs to consistent English
- normalized user-facing Vietnamese copy to avoid gender-specific wording like `anh`

## Verification

- `./vendor/bin/pint`
- `php artisan test tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php tests/Unit/Services/Auth/AuthProviderServiceTest.php tests/Unit/Repositories/Auth/AuthProviderRepositoryTest.php tests/Unit/Http/Resources/AdminAuthProviderResourceTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon app/Http/Controllers/Api/AdminAuthProviderApiController.php app/Http/Requests/UpdateAuthProviderRequest.php app/Http/Resources/AdminAuthProviderResource.php app/Services/Auth/AuthProviderConfigService.php app/Services/Auth/AuthProviderService.php app/Repositories/Auth/AuthProviderRepository.php`

Closes #61
