### PR TITLE
Feat(auth): render public login and registration methods from dynamic provider settings

### DIFF
--- a/apps/laravel/app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php
+++ b/apps/laravel/app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php
@@ -79,6 +79,7 @@ abstract class AbstractOAuthAuthProviderDriver extends AbstractAuthProviderDrive
             'button_text' => $config['button_text'] ?? sprintf('Continue with %s', $provider->display_name),
             'scopes' => $config['scopes'] ?? [],
             'pkce' => (bool) ($config['pkce'] ?? false),
+            'redirect_url' => route('api.auth.providers.redirect', ['key' => $provider->key]),
             'callback_url' => route('api.auth.providers.callback', ['key' => $provider->key]),
         ];
     }

--- a/apps/laravel/package-lock.json
+++ b/apps/laravel/package-lock.json
@@ -10,6 +10,8 @@
                 "react-router-dom": "^7.6.0"
             },
             "devDependencies": {
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.3.2",
                 "@vitejs/plugin-react": "^4.4.1",
                 "axios": "^1.8.2",
                 "concurrently": "^9.0.1",
@@ -17,11 +19,38 @@
                 "eslint-plugin-react": "^7.37.5",
                 "eslint-plugin-react-hooks": "^5.2.0",
                 "globals": "^16.1.0",
+                "jsdom": "^26.1.0",
                 "laravel-vite-plugin": "^1.2.0",
                 "prettier": "^3.5.3",
                 "sass": "^1.89.2",
-                "vite": "^6.2.4"
+                "vite": "^6.2.4",
+                "vitest": "^4.1.6"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "dev": true
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -241,6 +270,15 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -293,6 +331,116 @@
             "dev": true,
             "optional": true,
             "peer": true
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.5",
@@ -931,9 +1079,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-            "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1508,6 +1656,91 @@
                 "win32"
             ]
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true
+        },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+            "dev": true,
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1549,6 +1782,22 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1581,6 +1830,112 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+            "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+            "dev": true,
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+            "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "4.1.6",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+            "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+            "dev": true,
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+            "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/utils": "4.1.6",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+            "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+            "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+            "dev": true,
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+            "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.6",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1600,6 +1955,15 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -1647,6 +2011,15 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
@@ -1777,6 +2150,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/async-function": {
@@ -1965,6 +2347,15 @@
                 }
             ]
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2123,6 +2514,38 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true
+        },
+        "node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2191,6 +2614,12 @@
                 }
             }
         },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2240,6 +2669,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2261,6 +2699,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -2287,6 +2732,18 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/es-abstract": {
             "version": "1.24.2",
@@ -2400,6 +2857,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -2699,6 +3162,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2706,6 +3178,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -2727,10 +3208,13 @@
             "dev": true
         },
         "node_modules/fdir": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-            "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
+            },
             "peerDependencies": {
                 "picomatch": "^3 || ^4"
             },
@@ -3110,6 +3594,56 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3148,6 +3682,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/internal-slot": {
@@ -3395,6 +3938,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true
+        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3586,6 +4135,45 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jsesc": {
@@ -3979,6 +4567,25 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4007,6 +4614,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
@@ -4080,6 +4696,12 @@
             "version": "2.0.44",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
             "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+            "dev": true
+        },
+        "node_modules/nwsapi": {
+            "version": "2.2.23",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
             "dev": true
         },
         "node_modules/object-assign": {
@@ -4183,6 +4805,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ]
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4259,6 +4891,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4281,6 +4925,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true
         },
         "node_modules/picocolors": {
@@ -4361,6 +5011,41 @@
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -4473,6 +5158,19 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -4597,6 +5295,12 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true
+        },
         "node_modules/rxjs": {
             "version": "7.8.2",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -4657,6 +5361,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sass": {
             "version": "1.99.0",
@@ -4992,6 +5702,18 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -5165,6 +5887,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5173,6 +5901,18 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -5306,6 +6046,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5345,6 +6097,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "node_modules/sync-child-process": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -5370,20 +6128,86 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true
+        },
+        "node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tree-kill": {
@@ -5648,6 +6472,151 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+            "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/expect": "4.1.6",
+                "@vitest/mocker": "4.1.6",
+                "@vitest/pretty-format": "4.1.6",
+                "@vitest/runner": "4.1.6",
+                "@vitest/snapshot": "4.1.6",
+                "@vitest/spy": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.6",
+                "@vitest/browser-preview": "4.1.6",
+                "@vitest/browser-webdriverio": "4.1.6",
+                "@vitest/coverage-istanbul": "4.1.6",
+                "@vitest/coverage-v8": "4.1.6",
+                "@vitest/ui": "4.1.6",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5748,6 +6717,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5773,6 +6758,42 @@
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
+        },
+        "node_modules/ws": {
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/apps/laravel/package.json
+++ b/apps/laravel/package.json
@@ -9,10 +9,13 @@
         "ci": "npm run check && npm run build",
         "lint": "eslint resources/js --ext .js,.jsx",
         "lint:fix": "eslint resources/js --ext .js,.jsx --fix",
+        "test": "vitest run",
         "format": "prettier --write \"resources/js/**/*.{js,jsx}\"",
         "format:check": "prettier --check \"resources/js/**/*.{js,jsx}\""
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^4.4.1",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
@@ -20,10 +23,12 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^16.1.0",
+        "jsdom": "^26.1.0",
         "laravel-vite-plugin": "^1.2.0",
         "prettier": "^3.5.3",
         "sass": "^1.89.2",
-        "vite": "^6.2.4"
+        "vite": "^6.2.4",
+        "vitest": "^4.1.6"
     },
     "dependencies": {
         "react": "^18.3.1",

--- a/apps/laravel/resources/js/spa/components/layout/Header.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/Header.jsx
@@ -6,9 +6,8 @@ import LanguageSelect from './LanguageSelect';
 
 export default function Header({ title, description, onToggleSidebar }) {
     const navigate = useNavigate();
-    const { user, loading, logout, authProviders } = useAuth();
+    const { user, loading, logout, registerProviders } = useAuth();
     const { t } = useLanguage();
-    const emailProvider = authProviders.find((provider) => provider.key === 'email') ?? null;
 
     const handleLogout = async () => {
         await logout();
@@ -63,7 +62,7 @@ export default function Header({ title, description, onToggleSidebar }) {
                         <Link to="/login" className="app-button app-button--ghost">
                             {t('common.login')}
                         </Link>
-                        {emailProvider?.capabilities?.register ? (
+                        {registerProviders.length > 0 ? (
                             <Link to="/register" className="app-button app-button--primary">
                                 {t('common.register')}
                             </Link>

--- a/apps/laravel/resources/js/spa/features/auth/components/AuthProviderOptions.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/AuthProviderOptions.jsx
@@ -1,0 +1,13 @@
+import { renderPublicAuthProvider } from '../lib/publicAuthProviderRenderers';
+
+export default function AuthProviderOptions({ providers, action, t }) {
+    if (providers.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="app-form">
+            {providers.map((provider) => renderPublicAuthProvider(provider, action, t))}
+        </div>
+    );
+}

--- a/apps/laravel/resources/js/spa/features/auth/components/RedirectAuthProviderButton.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/RedirectAuthProviderButton.jsx
@@ -1,0 +1,27 @@
+import AppIcon, { hasAppIcon } from '../../../components/icons/AppIcon';
+import { getProviderActionText, getRedirectUrl } from '../lib/publicAuthProviders';
+
+function buildOauthButtonClass(key) {
+    return `app-button app-social-button app-social-button--${key}`;
+}
+
+export default function RedirectAuthProviderButton({ provider, action, t }) {
+    const actionText = getProviderActionText(provider, action, t);
+
+    return (
+        <a
+            className={buildOauthButtonClass(provider.key)}
+            href={getRedirectUrl(provider)}
+            aria-label={actionText}
+        >
+            {hasAppIcon(provider.icon) ? (
+                <span
+                    className={`app-social-button__icon app-social-button__icon--${provider.key}`}
+                >
+                    <AppIcon name={provider.icon} />
+                </span>
+            ) : null}
+            <span className="app-social-button__label">{actionText}</span>
+        </a>
+    );
+}

--- a/apps/laravel/resources/js/spa/features/auth/components/SensitiveInput.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/SensitiveInput.jsx
@@ -5,6 +5,7 @@ import AppIcon from '../../../components/icons/AppIcon';
  * Render a sensitive text input with a show/hide toggle.
  *
  * @param {{
+ *   id?: string,
  *   value: string,
  *   onChange?: ((event: import('react').ChangeEvent<HTMLInputElement>) => void) | undefined,
  *   placeholder?: string,
@@ -22,6 +23,7 @@ import AppIcon from '../../../components/icons/AppIcon';
  * @returns {import('react').JSX.Element}
  */
 export default function SensitiveInput({
+    id,
     value,
     onChange,
     placeholder = '',
@@ -41,6 +43,7 @@ export default function SensitiveInput({
     return (
         <div className={`app-sensitive-input ${className}`.trim()}>
             <input
+                id={id}
                 className={`app-input app-sensitive-input__control ${
                     invalid ? 'app-input--invalid' : ''
                 }`}

--- a/apps/laravel/resources/js/spa/features/auth/components/UnsupportedAuthProviderNotice.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/UnsupportedAuthProviderNotice.jsx
@@ -1,0 +1,9 @@
+import { getProviderActionText } from '../lib/publicAuthProviders';
+
+export default function UnsupportedAuthProviderNotice({ provider, action, t }) {
+    return (
+        <div className="app-provider-note" role="status">
+            {getProviderActionText(provider, action, t)}. {t('auth.providerUiUnavailableSuffix')}
+        </div>
+    );
+}

--- a/apps/laravel/resources/js/spa/features/auth/context/AuthContext.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/context/AuthContext.jsx
@@ -1,30 +1,15 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import api from '../../../lib/api';
+import { getProvidersForCapability } from '../lib/publicAuthProviders';
 
 const AuthContext = createContext(null);
-const fallbackEmailProvider = {
-    key: 'email',
-    display_name: 'Email and Password',
-    type: 'password',
-    icon: 'mail',
-    visibility: 'public',
-    active: true,
-    capabilities: {
-        login: true,
-        register: true,
-        requires_redirect: false,
-        supports_password: true,
-    },
-    metadata: {
-        button_text: 'Continue with email',
-    },
-};
 
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
     const [authProviders, setAuthProviders] = useState([]);
     const [providersLoading, setProvidersLoading] = useState(true);
+    const [providersError, setProvidersError] = useState(null);
 
     const refreshUser = useCallback(async () => {
         try {
@@ -38,12 +23,16 @@ export function AuthProvider({ children }) {
     }, []);
 
     const refreshAuthProviders = useCallback(async () => {
+        setProvidersLoading(true);
+        setProvidersError(null);
+
         try {
             const response = await api.get('/auth/providers');
-            const providers = response.data.data ?? [];
-            setAuthProviders(providers.length > 0 ? providers : [fallbackEmailProvider]);
+            const providers = Array.isArray(response.data.data) ? response.data.data : [];
+            setAuthProviders(providers);
         } catch {
-            setAuthProviders([fallbackEmailProvider]);
+            setAuthProviders([]);
+            setProvidersError('load_failed');
         } finally {
             setProvidersLoading(false);
         }
@@ -81,8 +70,11 @@ export function AuthProvider({ children }) {
             loading,
             authProviders,
             providersLoading,
+            providersError,
             isAuthenticated: Boolean(user),
             hasEmailLogin: authProviders.some((provider) => provider.key === 'email'),
+            loginProviders: getProvidersForCapability(authProviders, 'login'),
+            registerProviders: getProvidersForCapability(authProviders, 'register'),
             login,
             register,
             logout,
@@ -93,6 +85,7 @@ export function AuthProvider({ children }) {
             authProviders,
             loading,
             providersLoading,
+            providersError,
             user,
             login,
             register,

--- a/apps/laravel/resources/js/spa/features/auth/context/AuthContext.test.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/context/AuthContext.test.jsx
@@ -1,0 +1,91 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import api from '../../../lib/api';
+import { AuthProvider, useAuth } from './AuthContext';
+
+vi.mock('../../../lib/api', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+    },
+}));
+
+function AuthSnapshot() {
+    const { loginProviders, registerProviders, authProviders, providersError, providersLoading } =
+        useAuth();
+
+    return (
+        <div>
+            <span data-testid="loading">{providersLoading ? 'yes' : 'no'}</span>
+            <span data-testid="providers">{authProviders.length}</span>
+            <span data-testid="login-providers">{loginProviders.length}</span>
+            <span data-testid="register-providers">{registerProviders.length}</span>
+            <span data-testid="providers-error">{providersError ?? 'none'}</span>
+        </div>
+    );
+}
+
+describe('AuthContext', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('keeps an empty provider list empty when the backend exposes no providers', async () => {
+        api.get.mockImplementation((url) => {
+            if (url === '/auth/providers') {
+                return Promise.resolve({ data: { data: [] } });
+            }
+
+            if (url === '/auth/me') {
+                return Promise.reject(new Error('Unauthenticated.'));
+            }
+
+            throw new Error(`Unexpected url: ${url}`);
+        });
+
+        render(
+            <AuthProvider>
+                <AuthSnapshot />
+            </AuthProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('loading')).toHaveTextContent('no');
+        });
+
+        expect(screen.getByTestId('providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('login-providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('register-providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('providers-error')).toHaveTextContent('none');
+    });
+
+    it('reports provider loading failures instead of inventing a fallback provider', async () => {
+        api.get.mockImplementation((url) => {
+            if (url === '/auth/providers') {
+                return Promise.reject(new Error('Provider lookup failed.'));
+            }
+
+            if (url === '/auth/me') {
+                return Promise.reject(new Error('Unauthenticated.'));
+            }
+
+            throw new Error(`Unexpected url: ${url}`);
+        });
+
+        render(
+            <AuthProvider>
+                <AuthSnapshot />
+            </AuthProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('loading')).toHaveTextContent('no');
+        });
+
+        expect(screen.getByTestId('providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('login-providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('register-providers')).toHaveTextContent('0');
+        expect(screen.getByTestId('providers-error')).toHaveTextContent('load_failed');
+    });
+});

--- a/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviderRenderers.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviderRenderers.jsx
@@ -1,0 +1,38 @@
+import RedirectAuthProviderButton from '../components/RedirectAuthProviderButton';
+import UnsupportedAuthProviderNotice from '../components/UnsupportedAuthProviderNotice';
+import { isRedirectProvider } from './publicAuthProviders';
+
+function renderRedirectProvider(provider, action, t) {
+    return (
+        <RedirectAuthProviderButton key={provider.key} provider={provider} action={action} t={t} />
+    );
+}
+
+function renderUnsupportedProvider(provider, action, t) {
+    return (
+        <UnsupportedAuthProviderNotice
+            key={provider.key}
+            provider={provider}
+            action={action}
+            t={t}
+        />
+    );
+}
+
+const providerRenderers = Object.freeze({
+    oauth2: renderRedirectProvider,
+});
+
+export function renderPublicAuthProvider(provider, action, t) {
+    const renderer = providerRenderers[provider.type];
+
+    if (typeof renderer === 'function') {
+        return renderer(provider, action, t);
+    }
+
+    if (isRedirectProvider(provider)) {
+        return renderRedirectProvider(provider, action, t);
+    }
+
+    return renderUnsupportedProvider(provider, action, t);
+}

--- a/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.js
+++ b/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.js
@@ -1,0 +1,49 @@
+export function hasProviderCapability(provider, capability) {
+    return Boolean(provider?.capabilities?.[capability]);
+}
+
+export function getProvidersForCapability(providers, capability) {
+    if (!Array.isArray(providers)) {
+        return [];
+    }
+
+    return providers.filter((provider) => hasProviderCapability(provider, capability));
+}
+
+export function isPasswordProvider(provider) {
+    return provider?.type === 'password' || provider?.capabilities?.supports_password === true;
+}
+
+export function isRedirectProvider(provider) {
+    return provider?.capabilities?.requires_redirect === true || provider?.type === 'oauth2';
+}
+
+export function getPasswordFormProvider(providers) {
+    return (
+        providers.find((provider) => provider.key === 'email' && isPasswordProvider(provider)) ??
+        null
+    );
+}
+
+export function getNonFormProviders(providers, formProvider) {
+    return providers.filter((provider) => provider.key !== formProvider?.key);
+}
+
+export function getRedirectUrl(provider) {
+    return provider?.metadata?.redirect_url ?? `/api/auth/providers/${provider.key}/redirect`;
+}
+
+export function getProviderActionText(provider, action, t) {
+    if (action === 'register' && typeof provider?.metadata?.register_button_text === 'string') {
+        return provider.metadata.register_button_text;
+    }
+
+    if (action === 'login' && typeof provider?.metadata?.button_text === 'string') {
+        return provider.metadata.button_text;
+    }
+
+    const prefix =
+        action === 'register' ? t('auth.registerWithProvider') : t('auth.continueWithProvider');
+
+    return `${prefix} ${provider.display_name}`;
+}

--- a/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.jsx
@@ -1,37 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import AppIcon, { hasAppIcon } from '../../../components/icons/AppIcon';
 import ErrorState from '../../../components/ui/ErrorState';
 import AuthShowcase from '../components/AuthShowcase';
+import AuthProviderOptions from '../components/AuthProviderOptions';
 import SensitiveInput from '../components/SensitiveInput';
 import { useAuth } from '../context/AuthContext';
+import { getNonFormProviders, getPasswordFormProvider } from '../lib/publicAuthProviders';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 import LanguageSelect from '../../../components/layout/LanguageSelect';
-
-function buildOauthButtonClass(key) {
-    return `app-button app-social-button app-social-button--${key}`;
-}
-
-function oauthButtonText(provider, t) {
-    switch (provider.key) {
-        case 'google':
-            return 'Continue with Google';
-        case 'github':
-            return 'Continue with GitHub';
-        case 'facebook':
-            return 'Continue with Facebook';
-        default:
-            return (
-                provider.metadata?.button_text ||
-                `${t('auth.continueWithProvider')} ${provider.display_name}`
-            );
-    }
-}
 
 export default function LoginPage() {
     const navigate = useNavigate();
     const location = useLocation();
-    const { login, authProviders, providersLoading, refreshAuthProviders } = useAuth();
+    const { login, loginProviders, registerProviders, providersLoading, providersError } =
+        useAuth();
     const { t } = useLanguage();
     const [form, setForm] = useState({
         email: '',
@@ -43,12 +25,8 @@ export default function LoginPage() {
     const [fieldErrors, setFieldErrors] = useState({});
 
     const from = location.state?.from?.pathname || '/';
-    const emailProvider = authProviders.find((provider) => provider.key === 'email') ?? null;
-    const oauthProviders = authProviders.filter((provider) => provider.key !== 'email');
-
-    useEffect(() => {
-        void refreshAuthProviders();
-    }, [refreshAuthProviders]);
+    const emailProvider = getPasswordFormProvider(loginProviders);
+    const secondaryProviders = getNonFormProviders(loginProviders, emailProvider);
 
     useEffect(() => {
         const params = new URLSearchParams(location.search);
@@ -128,11 +106,17 @@ export default function LoginPage() {
                         <h2 className="app-form-card__title">{t('auth.loginTitle')}</h2>
                         <p className="app-form-card__text">{t('auth.loginText')}</p>
                         {providersLoading ? <p>{t('auth.providersLoading')}</p> : null}
+                        {!providersLoading && providersError ? (
+                            <ErrorState text={t('auth.providersLoadError')} />
+                        ) : null}
                         {emailProvider ? (
                             <form className="app-form" onSubmit={submit}>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.email')}</label>
+                                    <label className="app-label" htmlFor="login-email">
+                                        {t('auth.email')}
+                                    </label>
                                     <input
+                                        id="login-email"
                                         className={`app-input ${
                                             invalidEmail || fieldErrors.email?.[0]
                                                 ? 'app-input--invalid'
@@ -156,8 +140,11 @@ export default function LoginPage() {
                                     ) : null}
                                 </div>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.password')}</label>
+                                    <label className="app-label" htmlFor="login-password">
+                                        {t('auth.password')}
+                                    </label>
                                     <SensitiveInput
+                                        id="login-password"
                                         value={form.password}
                                         invalid={Boolean(fieldErrors.password?.[0] || error)}
                                         required
@@ -178,7 +165,10 @@ export default function LoginPage() {
                                     ) : null}
                                 </div>
                                 {flash ? (
-                                    <div className="app-provider-note app-provider-note--success">
+                                    <div
+                                        className="app-provider-note app-provider-note--success"
+                                        aria-live="polite"
+                                    >
                                         {flash}
                                     </div>
                                 ) : null}
@@ -195,39 +185,18 @@ export default function LoginPage() {
                                 </Link>
                             </form>
                         ) : null}
-                        {oauthProviders.length > 0 ? (
-                            <div className="app-form">
-                                {oauthProviders.map((provider) => (
-                                    <a
-                                        key={provider.key}
-                                        className={buildOauthButtonClass(provider.key)}
-                                        href={`/api/auth/providers/${provider.key}/redirect`}
-                                    >
-                                        {hasAppIcon(provider.icon) ? (
-                                            <span
-                                                className={`app-social-button__icon app-social-button__icon--${provider.key}`}
-                                            >
-                                                <AppIcon name={provider.icon} />
-                                            </span>
-                                        ) : null}
-                                        <span className="app-social-button__label">
-                                            {oauthButtonText(provider, t)}
-                                        </span>
-                                    </a>
-                                ))}
-                            </div>
-                        ) : null}
-                        {!providersLoading && authProviders.length === 0 ? (
+                        <AuthProviderOptions providers={secondaryProviders} action="login" t={t} />
+                        {!providersLoading && !providersError && loginProviders.length === 0 ? (
                             <ErrorState text={t('auth.noProvidersAvailable')} />
                         ) : null}
                         <div className="app-auth-panel__footer">
                             <span>{t('auth.noAccount')}</span>
-                            {emailProvider?.capabilities?.register ? (
+                            {registerProviders.length > 0 ? (
                                 <Link to="/register" className="app-inline-link">
                                     {t('auth.createAccount')}
                                 </Link>
                             ) : (
-                                <span>{t('auth.registrationUnavailable')}</span>
+                                <span aria-live="polite">{t('auth.registrationUnavailable')}</span>
                             )}
                         </div>
                     </article>

--- a/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.test.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.test.jsx
@@ -1,0 +1,196 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginPage from './LoginPage';
+
+const useAuthMock = vi.fn();
+const useLanguageMock = vi.fn();
+
+vi.mock('../context/AuthContext', () => ({
+    useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../../i18n/context/LanguageContext', () => ({
+    useLanguage: () => useLanguageMock(),
+}));
+
+vi.mock('../components/AuthShowcase', () => ({
+    default: () => <div>Auth showcase</div>,
+}));
+
+vi.mock('../../../components/layout/LanguageSelect', () => ({
+    default: () => <div>Language select</div>,
+}));
+
+vi.mock('../components/SensitiveInput', () => ({
+    default: ({ value = '', onChange, autoComplete, required }) => (
+        <input
+            type="password"
+            value={value}
+            onChange={onChange}
+            autoComplete={autoComplete}
+            required={required}
+        />
+    ),
+}));
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/login']}>
+            <LoginPage />
+        </MemoryRouter>,
+    );
+}
+
+function buildProvider(overrides = {}) {
+    return {
+        key: 'email',
+        display_name: 'Email and Password',
+        type: 'password',
+        icon: 'mail',
+        capabilities: {
+            login: true,
+            register: true,
+            requires_redirect: false,
+            supports_password: true,
+        },
+        metadata: {},
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    useLanguageMock.mockReturnValue({
+        t: (key) =>
+            ({
+                'auth.account': 'OPAS account',
+                'auth.backHome': 'Back to home',
+                'auth.loginTitle': 'Login',
+                'auth.loginText': 'Sign in to continue your work inside OPAS.',
+                'auth.providersLoading': 'Loading sign-in methods...',
+                'auth.providersLoadError': 'Unable to load authentication methods right now.',
+                'auth.noProvidersAvailable': 'No authentication providers are currently available.',
+                'auth.invalidEmail': 'Enter a valid email address.',
+                'auth.email': 'Email',
+                'auth.password': 'Password',
+                'auth.showValue': 'Show value',
+                'auth.hideValue': 'Hide value',
+                'auth.loginSubmitting': 'Signing in...',
+                'auth.loginSubmit': 'Sign in',
+                'auth.forgotPasswordLink': 'Forgot password?',
+                'auth.noAccount': "Don't have an account?",
+                'auth.createAccount': 'Create a new account',
+                'auth.registrationUnavailable': 'Account registration is currently unavailable.',
+                'auth.continueWithProvider': 'Continue with',
+                'auth.registerWithProvider': 'Register with',
+                'auth.providerUiUnavailableSuffix':
+                    'is available but this screen does not support it yet.',
+                'auth.loginError': 'Unable to sign in with this account.',
+                'auth.resetPasswordSuccess': 'Password updated successfully. You can sign in now.',
+                'auth.loginEyebrow': 'Welcome Back',
+                'auth.loginShowcaseTitle': 'Login showcase',
+                'auth.loginShowcaseText': 'Login showcase text',
+                'auth.marketTracking': 'Market tracking',
+                'auth.contentWorkflow': 'Content workflow',
+                'auth.automationAccess': 'Automation access',
+            })[key] ?? key,
+    });
+
+    useAuthMock.mockReturnValue({
+        login: vi.fn(),
+        loginProviders: [],
+        registerProviders: [],
+        providersLoading: false,
+        providersError: null,
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('LoginPage', () => {
+    it('renders only enabled login providers and keeps backend order', () => {
+        useAuthMock.mockReturnValue({
+            login: vi.fn(),
+            providersLoading: false,
+            providersError: null,
+            registerProviders: [buildProvider()],
+            loginProviders: [
+                buildProvider(),
+                buildProvider({
+                    key: 'github',
+                    display_name: 'GitHub',
+                    type: 'oauth2',
+                    icon: 'github',
+                    capabilities: {
+                        login: true,
+                        register: true,
+                        requires_redirect: true,
+                        supports_password: false,
+                    },
+                    metadata: {
+                        redirect_url: '/api/auth/providers/github/redirect',
+                    },
+                }),
+                buildProvider({
+                    key: 'google',
+                    display_name: 'Google',
+                    type: 'oauth2',
+                    icon: 'google',
+                    capabilities: {
+                        login: true,
+                        register: true,
+                        requires_redirect: true,
+                        supports_password: false,
+                    },
+                    metadata: {
+                        redirect_url: '/api/auth/providers/google/redirect',
+                    },
+                }),
+            ],
+        });
+
+        renderPage();
+
+        expect(screen.getAllByRole('textbox')).toHaveLength(1);
+        const githubLink = screen.getByRole('link', { name: 'Continue with GitHub' });
+        const googleLink = screen.getByRole('link', { name: 'Continue with Google' });
+
+        expect(githubLink).toHaveAttribute('href', '/api/auth/providers/github/redirect');
+        expect(googleLink).toHaveAttribute('href', '/api/auth/providers/google/redirect');
+        expect(
+            githubLink.compareDocumentPosition(googleLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ).not.toBe(0);
+        expect(
+            screen.queryByRole('link', { name: 'Continue with Facebook' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows the empty state when no login providers are available', () => {
+        renderPage();
+
+        expect(
+            screen.getByText('No authentication providers are currently available.'),
+        ).toBeInTheDocument();
+        expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+    });
+
+    it('shows the provider load error without inventing an email fallback', () => {
+        useAuthMock.mockReturnValue({
+            login: vi.fn(),
+            loginProviders: [],
+            registerProviders: [],
+            providersLoading: false,
+            providersError: 'load_failed',
+        });
+
+        renderPage();
+
+        expect(
+            screen.getByText('Unable to load authentication methods right now.'),
+        ).toBeInTheDocument();
+        expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+    });
+});

--- a/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.jsx
@@ -1,16 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import ErrorState from '../../../components/ui/ErrorState';
 import AuthShowcase from '../components/AuthShowcase';
+import AuthProviderOptions from '../components/AuthProviderOptions';
 import SensitiveInput from '../components/SensitiveInput';
 import { useAuth } from '../context/AuthContext';
 import { getMissingPasswordRuleKeys, isStrongPassword } from '../lib/passwordValidation';
+import { getNonFormProviders, getPasswordFormProvider } from '../lib/publicAuthProviders';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 import LanguageSelect from '../../../components/layout/LanguageSelect';
 
 export default function RegisterPage() {
     const navigate = useNavigate();
-    const { register, authProviders, providersLoading, refreshAuthProviders } = useAuth();
+    const { register, registerProviders, providersLoading, providersError } = useAuth();
     const { t } = useLanguage();
     const [form, setForm] = useState({
         name: '',
@@ -21,11 +23,8 @@ export default function RegisterPage() {
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState('');
     const [fieldErrors, setFieldErrors] = useState({});
-    const emailProvider = authProviders.find((provider) => provider.key === 'email') ?? null;
-
-    useEffect(() => {
-        void refreshAuthProviders();
-    }, [refreshAuthProviders]);
+    const emailProvider = getPasswordFormProvider(registerProviders);
+    const secondaryProviders = getNonFormProviders(registerProviders, emailProvider);
 
     const weakPassword = form.password.trim() !== '' && !isStrongPassword(form.password);
     const missingPasswordRuleKeys = getMissingPasswordRuleKeys(form.password);
@@ -100,11 +99,17 @@ export default function RegisterPage() {
                         <h2 className="app-form-card__title">{t('auth.registerTitle')}</h2>
                         <p className="app-form-card__text">{t('auth.registerText')}</p>
                         {providersLoading ? <p>{t('auth.providersLoading')}</p> : null}
+                        {!providersLoading && providersError ? (
+                            <ErrorState text={t('auth.providersLoadError')} />
+                        ) : null}
                         {emailProvider?.capabilities?.register ? (
                             <form className="app-form" onSubmit={submit}>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.name')}</label>
+                                    <label className="app-label" htmlFor="register-name">
+                                        {t('auth.name')}
+                                    </label>
                                     <input
+                                        id="register-name"
                                         className={`app-input ${fieldErrors.name?.[0] ? 'app-input--invalid' : ''}`}
                                         value={form.name}
                                         onChange={(event) =>
@@ -120,8 +125,11 @@ export default function RegisterPage() {
                                     ) : null}
                                 </div>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.email')}</label>
+                                    <label className="app-label" htmlFor="register-email">
+                                        {t('auth.email')}
+                                    </label>
                                     <input
+                                        id="register-email"
                                         className={`app-input ${
                                             invalidEmail || fieldErrors.email?.[0]
                                                 ? 'app-input--invalid'
@@ -152,8 +160,11 @@ export default function RegisterPage() {
                                     ) : null}
                                 </div>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.password')}</label>
+                                    <label className="app-label" htmlFor="register-password">
+                                        {t('auth.password')}
+                                    </label>
                                     <SensitiveInput
+                                        id="register-password"
                                         value={form.password}
                                         invalid={Boolean(weakPassword || fieldErrors.password?.[0])}
                                         required
@@ -187,8 +198,14 @@ export default function RegisterPage() {
                                     ) : null}
                                 </div>
                                 <div className="app-field">
-                                    <label className="app-label">{t('auth.confirmPassword')}</label>
+                                    <label
+                                        className="app-label"
+                                        htmlFor="register-password-confirmation"
+                                    >
+                                        {t('auth.confirmPassword')}
+                                    </label>
                                     <SensitiveInput
+                                        id="register-password-confirmation"
                                         value={form.password_confirmation}
                                         invalid={Boolean(
                                             passwordMismatch ||
@@ -227,7 +244,13 @@ export default function RegisterPage() {
                                         : t('auth.registerSubmit')}
                                 </button>
                             </form>
-                        ) : !providersLoading ? (
+                        ) : null}
+                        <AuthProviderOptions
+                            providers={secondaryProviders}
+                            action="register"
+                            t={t}
+                        />
+                        {!providersLoading && !providersError && registerProviders.length === 0 ? (
                             <ErrorState text={t('auth.registrationUnavailable')} />
                         ) : null}
                         <div className="app-auth-panel__footer">

--- a/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.test.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.test.jsx
@@ -1,0 +1,178 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RegisterPage from './RegisterPage';
+
+const useAuthMock = vi.fn();
+const useLanguageMock = vi.fn();
+
+vi.mock('../context/AuthContext', () => ({
+    useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../../i18n/context/LanguageContext', () => ({
+    useLanguage: () => useLanguageMock(),
+}));
+
+vi.mock('../components/AuthShowcase', () => ({
+    default: () => <div>Auth showcase</div>,
+}));
+
+vi.mock('../../../components/layout/LanguageSelect', () => ({
+    default: () => <div>Language select</div>,
+}));
+
+vi.mock('../components/SensitiveInput', () => ({
+    default: ({ value = '', onChange, autoComplete, required }) => (
+        <input
+            type="password"
+            value={value}
+            onChange={onChange}
+            autoComplete={autoComplete}
+            required={required}
+        />
+    ),
+}));
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/register']}>
+            <RegisterPage />
+        </MemoryRouter>,
+    );
+}
+
+function buildProvider(overrides = {}) {
+    return {
+        key: 'email',
+        display_name: 'Email and Password',
+        type: 'password',
+        icon: 'mail',
+        capabilities: {
+            login: true,
+            register: true,
+            requires_redirect: false,
+            supports_password: true,
+        },
+        metadata: {},
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    useLanguageMock.mockReturnValue({
+        t: (key) =>
+            ({
+                'auth.account': 'OPAS account',
+                'auth.backHome': 'Back to home',
+                'auth.registerTitle': 'Register',
+                'auth.registerText': 'Create a new account and start with the member role.',
+                'auth.providersLoading': 'Loading sign-in methods...',
+                'auth.providersLoadError': 'Unable to load authentication methods right now.',
+                'auth.registrationUnavailable': 'Account registration is currently unavailable.',
+                'auth.name': 'Name',
+                'auth.email': 'Email',
+                'auth.invalidEmail': 'Enter a valid email address.',
+                'auth.password': 'Password',
+                'auth.confirmPassword': 'Confirm password',
+                'auth.showValue': 'Show value',
+                'auth.hideValue': 'Hide value',
+                'auth.passwordRuleIntro': 'Your password must satisfy all of these rules:',
+                'auth.passwordRuleFail': 'Missing:',
+                'auth.passwordConfirmMismatch': 'The password confirmation does not match.',
+                'auth.registerSubmitting': 'Creating...',
+                'auth.registerSubmit': 'Create account',
+                'auth.haveAccount': 'Already have an account?',
+                'auth.goToLogin': 'Go to login',
+                'auth.registerWithProvider': 'Register with',
+                'auth.providerUiUnavailableSuffix':
+                    'is available but this screen does not support it yet.',
+                'auth.registerError': 'Unable to create this account. Please review your details.',
+                'auth.registerEyebrow': 'Create Your Access',
+                'auth.registerShowcaseTitle': 'Register showcase',
+                'auth.registerShowcaseText': 'Register showcase text',
+                'auth.member': 'Member',
+                'auth.plus': 'Plus',
+                'auth.vip': 'VIP',
+                'auth.admin': 'Admin',
+                'auth.passwordRuleMinLength': 'at least 8 characters',
+                'auth.passwordRuleLowercase': 'at least one lowercase letter',
+                'auth.passwordRuleUppercase': 'at least one uppercase letter',
+                'auth.passwordRuleNumber': 'at least one number',
+                'auth.passwordRuleSymbol': 'at least one special character',
+            })[key] ?? key,
+    });
+
+    useAuthMock.mockReturnValue({
+        register: vi.fn(),
+        registerProviders: [],
+        providersLoading: false,
+        providersError: null,
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('RegisterPage', () => {
+    it('renders password and redirect registration methods dynamically', () => {
+        useAuthMock.mockReturnValue({
+            register: vi.fn(),
+            providersLoading: false,
+            providersError: null,
+            registerProviders: [
+                buildProvider(),
+                buildProvider({
+                    key: 'github',
+                    display_name: 'GitHub',
+                    type: 'oauth2',
+                    icon: 'github',
+                    capabilities: {
+                        login: true,
+                        register: true,
+                        requires_redirect: true,
+                        supports_password: false,
+                    },
+                    metadata: {
+                        redirect_url: '/api/auth/providers/github/redirect',
+                    },
+                }),
+            ],
+        });
+
+        renderPage();
+
+        expect(screen.getAllByRole('textbox')).toHaveLength(2);
+        expect(screen.getByRole('link', { name: 'Register with GitHub' })).toHaveAttribute(
+            'href',
+            '/api/auth/providers/github/redirect',
+        );
+    });
+
+    it('shows the register unavailable state when no register providers exist', () => {
+        renderPage();
+
+        expect(
+            screen.getByText('Account registration is currently unavailable.'),
+        ).toBeInTheDocument();
+        expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+    });
+
+    it('shows the provider load error when provider discovery fails', () => {
+        useAuthMock.mockReturnValue({
+            register: vi.fn(),
+            registerProviders: [],
+            providersLoading: false,
+            providersError: 'load_failed',
+        });
+
+        renderPage();
+
+        expect(
+            screen.getByText('Unable to load authentication methods right now.'),
+        ).toBeInTheDocument();
+        expect(screen.queryAllByRole('textbox')).toHaveLength(0);
+    });
+});

--- a/apps/laravel/resources/js/spa/features/i18n/messages/en.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/en.js
@@ -100,6 +100,7 @@ export const enMessages = {
         resetPasswordShowcaseText:
             'Choose a strong password you can remember and use it for future sign-in.',
         providersLoading: 'Loading sign-in methods...',
+        providersLoadError: 'Unable to load authentication methods right now.',
         noProvidersAvailable: 'No authentication providers are currently available.',
         registrationUnavailable: 'Account registration is currently unavailable.',
         invalidEmail: 'Enter a valid email address.',
@@ -114,6 +115,8 @@ export const enMessages = {
         passwordRuleNumber: 'at least one number',
         passwordRuleSymbol: 'at least one special character',
         continueWithProvider: 'Continue with',
+        registerWithProvider: 'Register with',
+        providerUiUnavailableSuffix: 'is available but this screen does not support it yet.',
         noAccount: "Don't have an account?",
         createAccount: 'Create a new account',
         loginEyebrow: 'Welcome Back',

--- a/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
@@ -100,6 +100,7 @@ export const viMessages = {
         resetPasswordShowcaseText:
             'Hãy chọn một mật khẩu mạnh, dễ nhớ và dùng nó cho những lần đăng nhập sau.',
         providersLoading: 'Đang tải phương thức đăng nhập...',
+        providersLoadError: 'Hiện không thể tải danh sách phương thức đăng nhập.',
         noProvidersAvailable: 'Hiện chưa có phương thức đăng nhập nào khả dụng.',
         registrationUnavailable: 'Hiện chưa thể đăng ký tài khoản mới.',
         invalidEmail: 'Hãy nhập đúng định dạng email.',
@@ -114,6 +115,9 @@ export const viMessages = {
         passwordRuleNumber: 'ít nhất 1 chữ số',
         passwordRuleSymbol: 'ít nhất 1 ký tự đặc biệt',
         continueWithProvider: 'Tiếp tục với',
+        registerWithProvider: 'Đăng ký với',
+        providerUiUnavailableSuffix:
+            'đang khả dụng nhưng màn hình này chưa hỗ trợ hiển thị trực tiếp.',
         noAccount: 'Chưa có tài khoản?',
         createAccount: 'Tạo tài khoản mới',
         loginEyebrow: 'Welcome Back',

--- a/apps/laravel/resources/js/test/setup.js
+++ b/apps/laravel/resources/js/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthApiControllerTest.php
@@ -232,6 +232,66 @@ class AuthApiControllerTest extends TestCase
     }
 
     /**
+     * Login must also be blocked when the email provider no longer exposes the login capability.
+     */
+    public function test_it_blocks_email_login_when_login_capability_is_disabled(): void
+    {
+        AuthProvider::query()->where('key', 'email')->update([
+            'capabilities' => [
+                'login' => false,
+                'register' => true,
+                'link_account' => false,
+                'requires_redirect' => false,
+                'supports_email_verification' => true,
+                'supports_password' => true,
+            ],
+        ]);
+
+        $user = User::factory()->create([
+            'password' => 'Password123!',
+        ]);
+
+        $response = $this->postJson(route('api.auth.login'), [
+            'email' => $user->email,
+            'password' => 'Password123!',
+        ]);
+
+        $response->assertForbidden()
+            ->assertJson([
+                'message' => 'Email login is not available.',
+            ]);
+    }
+
+    /**
+     * Registration must be blocked when the email provider keeps login enabled but disables register.
+     */
+    public function test_it_blocks_email_registration_when_register_capability_is_disabled(): void
+    {
+        AuthProvider::query()->where('key', 'email')->update([
+            'capabilities' => [
+                'login' => true,
+                'register' => false,
+                'link_account' => false,
+                'requires_redirect' => false,
+                'supports_email_verification' => true,
+                'supports_password' => true,
+            ],
+        ]);
+
+        $response = $this->postJson(route('api.auth.register'), [
+            'name' => 'OPAS User',
+            'email' => 'capability-disabled@gmail.com',
+            'password' => 'Password123!',
+            'password_confirmation' => 'Password123!',
+        ]);
+
+        $response->assertForbidden()
+            ->assertJson([
+                'message' => 'Email registration is not available.',
+            ]);
+    }
+
+    /**
      * Unverified accounts should be able to request a fresh verification code.
      */
     public function test_it_can_resend_verification_email_for_unverified_account(): void

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php
@@ -42,10 +42,56 @@ class AuthProviderApiControllerTest extends TestCase
             ->assertJsonPath('data.0.key', 'email')
             ->assertJsonPath('data.1.key', 'google')
             ->assertJsonPath(
+                'data.1.metadata.redirect_url',
+                route('api.auth.providers.redirect', ['key' => 'google']),
+            )
+            ->assertJsonPath(
                 'data.1.metadata.callback_url',
                 route('api.auth.providers.callback', ['key' => 'google']),
             )
+            ->assertJsonMissingPath('data.1.secret_config')
+            ->assertJsonMissingPath('data.1.metadata.client_secret')
             ->assertJsonMissingPath('data.2');
+    }
+
+    /**
+     * Public provider ordering should follow the configured backend sort order.
+     */
+    public function test_it_keeps_public_provider_ordering_from_backend_configuration(): void
+    {
+        $google = AuthProvider::query()->where('key', 'google')->firstOrFail();
+        $github = AuthProvider::query()->where('key', 'github')->firstOrFail();
+
+        $google->update([
+            'enabled' => true,
+            'sort_order' => 40,
+            'public_config' => [
+                'client_id' => 'google-client-id',
+                'redirect_uri' => 'https://example.com/auth/google/callback',
+            ],
+            'secret_config' => [
+                'client_secret' => 'google-secret',
+            ],
+        ]);
+
+        $github->update([
+            'enabled' => true,
+            'sort_order' => 15,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => 'https://example.com/auth/github/callback',
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        $response = $this->getJson(route('api.auth.providers.index'));
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.key', 'email')
+            ->assertJsonPath('data.1.key', 'github')
+            ->assertJsonPath('data.2.key', 'google');
     }
 
     /**

--- a/apps/laravel/vitest.config.js
+++ b/apps/laravel/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default defineConfig({
+    ...viteConfig,
+    test: {
+        environment: 'jsdom',
+        setupFiles: ['./resources/js/test/setup.js'],
+    },
+});


### PR DESCRIPTION
## Summary
This PR closes #63 by updating the public authentication UI so login and registration methods are rendered dynamically from backend provider settings instead of hardcoded frontend assumptions.

## What changed
- Removed the fake email fallback from the public auth context.
- Loaded public auth providers directly from `/api/auth/providers` as the single source of truth.
- Added explicit provider states for:
  - loading
  - load error
  - no providers available
  - unsupported provider renderer
- Refactored login and register screens to render methods dynamically by provider capability and type.
- Rendered Email/Password only when the email provider is enabled and available.
- Rendered Google, Facebook, and GitHub buttons only when each provider is enabled, ready, and public.
- Preserved backend-defined provider ordering on the public auth screens.
- Added a provider renderer layer so future provider types can be introduced more cleanly.
- Exposed safe public redirect metadata for OAuth providers without leaking secrets.
- Added frontend tests for conditional rendering and provider state handling.
- Expanded backend tests for:
  - public provider ordering
  - hidden/incomplete provider filtering
  - no secret exposure in public provider responses
  - login/register capability guardrails

## Result
- Login and register pages now reflect enabled provider settings automatically.
- Disabled providers no longer appear in the UI.
- The no-provider-enabled state now behaves correctly instead of falling back to email.
- The rendering flow is cleaner and more extensible for future providers.

## Verification
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`
- `./vendor/bin/pint app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthApiControllerTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php`
- `php artisan test tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthApiControllerTest.php tests/Unit/Services/Auth/AuthProviderServiceTest.php tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php`

Closes #63
