### PR TITLE
Feat: finalize Facebook OAuth coverage and setup flow

### DIFF
--- a/apps/laravel/resources/js/spa/App.jsx
+++ b/apps/laravel/resources/js/spa/App.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import AdminShell from './components/layout/AdminShell';
 import AppShell from './components/layout/AppShell';
@@ -24,9 +25,23 @@ import { LanguageProvider } from './features/i18n/context/LanguageContext';
  * Web routes in Laravel now point to a single Blade entry,
  * while React Router handles screen-level navigation here.
  */
+function FacebookRedirectHashCleanup() {
+    useEffect(() => {
+        if (window.location.hash !== '#_=_') {
+            return;
+        }
+
+        const cleanUrl = `${window.location.pathname}${window.location.search}`;
+        window.history.replaceState(null, document.title, cleanUrl);
+    }, []);
+
+    return null;
+}
+
 export default function App() {
     return (
         <BrowserRouter>
+            <FacebookRedirectHashCleanup />
             <LanguageProvider>
                 <AuthProvider>
                     <Routes>

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/providerDocs.js
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/providerDocs.js
@@ -1,8 +1,26 @@
-function buildGoogleDocs(language, callbackUrl) {
+function resolveWebsiteUrl(callbackUrl, language) {
+    try {
+        return new URL(callbackUrl).origin;
+    } catch {
+        return language === 'vi' ? 'domain hiện tại của website' : 'the current website domain';
+    }
+}
+
+function isLocalCallbackUrl(callbackUrl) {
+    try {
+        const parsedUrl = new URL(callbackUrl);
+
+        return ['localhost', '127.0.0.1', '::1'].includes(parsedUrl.hostname);
+    } catch {
+        return false;
+    }
+}
+
+function buildGoogleDocs(language, callbackUrl, websiteUrl) {
     if (language === 'vi') {
         return {
             title: 'Hướng dẫn cấu hình Google OAuth',
-            intro: 'Chỉ cần tạo một **OAuth client** trên **Google Cloud Console**, copy **Client ID**, **Client Secret**, rồi dán đúng **Redirect URI** là dùng được.',
+            intro: 'Mở đúng project trong **Google Cloud Console**, tạo **OAuth client ID** loại **Web application**, rồi copy chính xác **Client ID**, **Client Secret** và **Redirect URI** theo môi trường hiện tại.',
             links: [
                 {
                     label: 'Mở Google Cloud Console',
@@ -17,30 +35,41 @@ function buildGoogleDocs(language, callbackUrl) {
                 {
                     title: '1. Vào đúng màn hình tạo OAuth',
                     items: [
-                        'Mở **Google Cloud Console**.',
+                        'Mở **Google Cloud Console** từ link bên trên.',
                         'Chọn project đang dùng cho website này, hoặc tạo project mới nếu chưa có.',
                         'Vào **APIs & Services** > **Credentials**.',
+                        `Nếu cần điền URL website hiện tại ở bước nào đó, dùng: \`${websiteUrl}\`.`,
                     ],
                 },
                 {
-                    title: '2. Tạo OAuth client',
+                    title: '2. Chuẩn bị OAuth consent screen nếu Google yêu cầu',
                     items: [
-                        'Bấm **Create Credentials** > **OAuth client ID**.',
-                        'Nếu Google yêu cầu, cấu hình nhanh **OAuth consent screen** với **App name**, **Support email**, và **Developer contact email**.',
-                        'Ở phần **Application type**, chọn **Web application**.',
-                        'Đặt tên dễ hiểu, ví dụ: **OPAS Google Login**.',
+                        'Nếu chưa cấu hình consent screen, bấm **Get started** hoặc vào **OAuth consent screen**.',
+                        'Điền **App name** dễ hiểu, ví dụ: **OPAS Login** hoặc **OPAS Google Login**.',
+                        'Chọn **User support email** và nhập **Developer contact email**.',
+                        'Nếu app đang ở chế độ test, thêm tài khoản test vào danh sách **Test users** để kiểm tra local hoặc staging.',
                     ],
                 },
                 {
-                    title: '3. Nhập Redirect URI đúng 100%',
+                    title: '3. Tạo OAuth client ID',
                     items: [
-                        'Trong ô **Authorized redirect URIs**, dán đúng URL này:',
+                        'Quay lại **APIs & Services** > **Credentials**.',
+                        'Bấm **+ Create Credentials** > **OAuth client ID**.',
+                        'Ở **Application type**, chọn **Web application**.',
+                        'Đặt tên dễ hiểu, ví dụ: **OPAS Web Login**.',
+                    ],
+                },
+                {
+                    title: '4. Khai báo đúng website URL và Redirect URI',
+                    items: [
+                        `Trong **Authorized JavaScript origins**, thêm URL website hiện tại nếu bạn muốn khai báo origin: \`${websiteUrl}\`.`,
+                        'Trong **Authorized redirect URIs**, dán đúng URL callback bên dưới:',
                         `\`${callbackUrl}\``,
                         'Sai chỉ 1 ký tự cũng sẽ gây lỗi **redirect_uri_mismatch**.',
                     ],
                 },
                 {
-                    title: '4. Copy giá trị về form này',
+                    title: '5. Copy giá trị về form này',
                     items: [
                         '**Client ID**: copy từ Google.',
                         '**Client Secret**: copy từ Google.',
@@ -49,7 +78,7 @@ function buildGoogleDocs(language, callbackUrl) {
                     ],
                 },
                 {
-                    title: '5. Nếu đăng nhập chưa chạy',
+                    title: '6. Nếu đăng nhập chưa chạy',
                     items: [
                         'Lỗi **redirect_uri_mismatch**: kiểm tra lại **Redirect URI** ở cả 2 bên.',
                         'Lỗi **app not verified** hoặc **access blocked**: thêm tài khoản test vào **OAuth consent screen** nếu app còn ở chế độ test.',
@@ -71,6 +100,10 @@ function buildGoogleDocs(language, callbackUrl) {
                     text: `Google sẽ trả người dùng về URL này sau khi đăng nhập. Giá trị đúng là \`${callbackUrl}\`.`,
                 },
                 {
+                    label: 'Website URL',
+                    text: `Nếu Google yêu cầu **Authorized JavaScript origins** hoặc cần đối chiếu domain hiện tại, dùng \`${websiteUrl}\`.`,
+                },
+                {
                     label: 'Visibility',
                     text: 'Chọn **public** khi muốn hiện nút ngoài trang login. Nếu còn test, có thể để **hidden** trước.',
                 },
@@ -84,7 +117,7 @@ function buildGoogleDocs(language, callbackUrl) {
 
     return {
         title: 'Google OAuth setup guide',
-        intro: 'Create one **OAuth client** in **Google Cloud Console**, copy **Client ID**, **Client Secret**, and use the exact **Redirect URI** below.',
+        intro: 'Open the correct project in **Google Cloud Console**, create a **Web application OAuth client**, then copy the exact **Client ID**, **Client Secret**, and environment-specific **Redirect URI**.',
         links: [
             {
                 label: 'Open Google Cloud Console',
@@ -99,29 +132,41 @@ function buildGoogleDocs(language, callbackUrl) {
             {
                 title: '1. Open the correct Google screen',
                 items: [
-                    'Open **Google Cloud Console**.',
+                    'Open **Google Cloud Console** from the link above.',
                     'Select the project for this website, or create one if needed.',
                     'Go to **APIs & Services** > **Credentials**.',
+                    `Use this website URL if Google asks for the current site domain: \`${websiteUrl}\`.`,
                 ],
             },
             {
-                title: '2. Create the OAuth client',
+                title: '2. Prepare the OAuth consent screen if Google asks for it',
                 items: [
-                    'Click **Create Credentials** > **OAuth client ID**.',
-                    'If prompted, complete **OAuth consent screen** with **App name**, **Support email**, and **Developer contact email**.',
+                    'If the consent screen is not configured yet, click **Get started** or open **OAuth consent screen**.',
+                    'Set a clear **App name** such as **OPAS Login** or **OPAS Google Login**.',
+                    'Select the **User support email** and enter the **Developer contact email**.',
+                    'If the app stays in testing mode, add your local or staging accounts as **Test users**.',
+                ],
+            },
+            {
+                title: '3. Create the OAuth client ID',
+                items: [
+                    'Return to **APIs & Services** > **Credentials**.',
+                    'Click **+ Create Credentials** > **OAuth client ID**.',
                     'Choose **Web application** as the application type.',
+                    'Use a clear name such as **OPAS Web Login**.',
                 ],
             },
             {
-                title: '3. Register the exact Redirect URI',
+                title: '4. Register the website URL and Redirect URI',
                 items: [
-                    'Paste this exact value into **Authorized redirect URIs**:',
+                    `Add the current website URL to **Authorized JavaScript origins** if you want to register the origin: \`${websiteUrl}\`.`,
+                    'Paste this exact callback into **Authorized redirect URIs**:',
                     `\`${callbackUrl}\``,
                     'A one-character mismatch will trigger **redirect_uri_mismatch**.',
                 ],
             },
             {
-                title: '4. Copy the values into this form',
+                title: '5. Copy the values into this form',
                 items: [
                     '**Client ID**: copy it from Google.',
                     '**Client Secret**: copy it from Google.',
@@ -130,7 +175,7 @@ function buildGoogleDocs(language, callbackUrl) {
                 ],
             },
             {
-                title: '5. If sign-in still fails',
+                title: '6. If sign-in still fails',
                 items: [
                     '**redirect_uri_mismatch**: the **Redirect URI** values do not match.',
                     '**app not verified** or **access blocked**: add your account as a test user in **OAuth consent screen**.',
@@ -150,6 +195,10 @@ function buildGoogleDocs(language, callbackUrl) {
             {
                 label: 'Redirect URI',
                 text: `Google sends the user back to this URL after sign-in: \`${callbackUrl}\`.`,
+            },
+            {
+                label: 'Website URL',
+                text: `If Google asks for the current site origin, use \`${websiteUrl}\`.`,
             },
             {
                 label: 'Visibility',
@@ -309,11 +358,24 @@ function buildGithubDocs(language, callbackUrl) {
     };
 }
 
-function buildFacebookDocs(language, callbackUrl) {
+function buildFacebookDocs(language, callbackUrl, websiteUrl) {
+    const isLocalCallback = isLocalCallbackUrl(callbackUrl);
+
     if (language === 'vi') {
+        const localWarningStep = isLocalCallback
+            ? {
+                  title: '0. Trường hợp test local bằng localhost',
+                  items: [
+                      `Bạn đang test bằng callback local: \`${callbackUrl}\`.`,
+                      'Với app còn ở **Development mode**, Meta thường vẫn cho test bằng `http://localhost`, nhưng nhiều trường hợp bạn phải cấu hình **Website platform** trước rồi mới lưu được **Valid OAuth Redirect URI**.',
+                      'Nếu bạn vừa tạo app xong mà Meta báo URI chuyển hướng không hợp lệ, hãy làm tiếp đúng các bước thêm **Website** và nhập **Site URL** ở bên dưới rồi quay lại lưu callback.',
+                  ],
+              }
+            : null;
+
         return {
             title: 'Hướng dẫn cấu hình Facebook Login',
-            intro: 'Tạo app trong **Meta for Developers**, bật **Facebook Login**, rồi dán đúng **App ID**, **App Secret** và **Redirect URI**.',
+            intro: 'Tạo app mới trong **Meta for Developers**, thêm **Facebook Login**, cấu hình **Website platform**, rồi điền đúng **App ID**, **App Secret** và **Redirect URI** theo môi trường hiện tại.',
             links: [
                 {
                     label: 'Mở Meta for Developers',
@@ -325,31 +387,58 @@ function buildFacebookDocs(language, callbackUrl) {
                 },
             ],
             steps: [
+                ...(localWarningStep ? [localWarningStep] : []),
                 {
-                    title: '1. Chuẩn bị môi trường cấu hình',
+                    title: '1. Tạo ứng dụng mới từ đầu',
                     items: [
-                        'Mở **Meta for Developers**.',
-                        'Tạo app hoặc chọn app đang dùng cho website này.',
-                        `URL cần dùng cho **Valid OAuth Redirect URI** là: \`${callbackUrl}\`.`,
+                        'Mở **Meta for Developers** từ link bên trên.',
+                        'Bấm **Create App**.',
+                        'Nếu Meta hỏi use case, chọn use case phù hợp cho **Facebook Login**. Nếu bạn chỉ cần vào app dashboard nhanh để tự cấu hình tiếp thì có thể chọn **Other**.',
+                        'Ở bước loại ứng dụng, với luồng đăng nhập người dùng cuối, chọn loại tương ứng với **Consumer** nếu Meta hiển thị lựa chọn này.',
+                        'Nhập **Display Name** dễ hiểu, ví dụ: **OPAS Login**, **OPAS Facebook Login** hoặc **Test Login Localhost**.',
+                        'Nhập email liên hệ.',
+                        'Nếu không dùng hồ sơ doanh nghiệp, để trống phần **Business** rồi bấm **Create App**.',
                     ],
                 },
                 {
-                    title: '2. Tạo app trên Meta',
+                    title: '2. Thêm sản phẩm Facebook Login',
                     items: [
-                        'Vào Meta for Developers và tạo app phù hợp cho Facebook Login.',
-                        'Thêm sản phẩm Facebook Login vào app.',
+                        'Trong màn hình quản trị app, tìm **Facebook Login** rồi bấm **Set up**.',
+                        'Nếu Meta hỏi nền tảng, chọn **Web**.',
+                        `Chuẩn bị sẵn URL website hiện tại để dùng ở bước nền tảng: \`${websiteUrl}\`.`,
                     ],
                 },
                 {
-                    title: '3. Cấu hình Redirect URI',
+                    title: '3. Thêm Website platform trong Settings > Basic',
                     items: [
-                        'Trong **Facebook Login settings**, dán đúng URL này:',
+                        'Ở menu bên trái, vào **Settings** > **Basic**.',
+                        'Cuộn xuống cuối trang và bấm **Add Platform**.',
+                        'Chọn **Website**.',
+                        `Trong ô **Site URL**, nhập đúng URL website hiện tại: \`${websiteUrl}/\`.`,
+                        'Bấm **Save Changes**.',
+                    ],
+                },
+                {
+                    title: '4. Cấu hình Valid OAuth Redirect URI',
+                    items: [
+                        'Mở **Facebook Login** > **Settings**.',
+                        'Trong ô **Valid OAuth Redirect URIs**, dán đúng URL này:',
                         `\`${callbackUrl}\``,
+                        'Nếu trước đó Meta không cho lưu callback local, bước thêm **Website** và **Site URL** ở trên thường là phần còn thiếu.',
                         'Nếu sai, Facebook sẽ từ chối callback.',
+                        'Sau đó bấm **Save Changes**.',
                     ],
                 },
                 {
-                    title: '4. Điền App ID và App Secret',
+                    title: '5. Kiểm tra App Domains và chế độ Development',
+                    items: [
+                        'Trong **Settings** > **Basic**, mục **App Domains** có thể để trống hoặc nhập `localhost` nếu Meta yêu cầu.',
+                        'Khi app còn ở **Development mode**, bạn có thể test local bằng `http://localhost` mà chưa cần business verification.',
+                        'Không cần đổi sang **Live mode** chỉ để test local.',
+                    ],
+                },
+                {
+                    title: '6. Điền App ID và App Secret vào form này',
                     items: [
                         '**Client ID**: dùng **App ID**.',
                         '**Client Secret**: dùng **App Secret** trong **App Settings** > **Basic**.',
@@ -357,18 +446,21 @@ function buildFacebookDocs(language, callbackUrl) {
                     ],
                 },
                 {
-                    title: '5. Kiểm tra chế độ app',
+                    title: '7. Nếu bấm login mà báo Ứng dụng không hoạt động',
                     items: [
-                        'Nếu app còn ở chế độ development, chỉ những tài khoản được cấp quyền mới test được.',
-                        'Khi muốn dùng thật cho người dùng ngoài hệ thống, kiểm tra thêm các bước review/publish của Meta nếu cần.',
+                        'Lỗi này thường có nghĩa là app vẫn ở **Development mode** và tài khoản Facebook đang bấm login không phải **admin/developer/tester** của app.',
+                        'Cách nhanh nhất là test bằng chính tài khoản Facebook đã tạo app.',
+                        'Nếu muốn test bằng tài khoản khác, vào mục **Roles** của app và thêm tài khoản đó làm **Developer** hoặc **Tester**.',
+                        'Tài khoản được mời phải đăng nhập Facebook và **accept** lời mời thì mới test được.',
                     ],
                 },
                 {
-                    title: '6. Lỗi thường gặp',
+                    title: '8. Lỗi thường gặp',
                     items: [
-                        'URL bị từ chối: Valid OAuth Redirect URI chưa khai báo đúng.',
-                        'Đăng nhập không cho tài khoản ngoài dùng: app vẫn đang ở development mode.',
+                        'Meta báo **Đây là URI chuyển hướng không hợp lệ**: thường là bạn chưa thêm **Website** platform hoặc chưa lưu **Site URL** trước khi nhập callback.',
+                        'Meta báo **Ứng dụng không hoạt động**: tài khoản test chưa thuộc **Roles** của app hoặc bạn đang đăng nhập bằng tài khoản khác tài khoản tạo app.',
                         'Sai App Secret: secret bị copy thiếu hoặc đã bị thay đổi trong Meta.',
+                        'Nếu đã làm đúng các bước mà local callback vẫn bị Meta chặn ở môi trường của bạn, khi đó mới chuyển sang dùng domain/tunnel public rồi để hệ thống sinh callback mới từ `APP_URL`.',
                     ],
                 },
             ],
@@ -385,13 +477,28 @@ function buildFacebookDocs(language, callbackUrl) {
                     label: 'Redirect URI',
                     text: `Meta sẽ redirect về URL này sau khi xác thực: \`${callbackUrl}\`.`,
                 },
+                {
+                    label: 'Website URL',
+                    text: `Nếu Meta hỏi **Site URL**, dùng \`${websiteUrl}/\`. Nếu hỏi **App Domains**, có thể để trống hoặc nhập \`localhost\` khi đang test local.`,
+                },
             ],
         };
     }
 
+    const localWarningStep = isLocalCallback
+        ? {
+              title: '0. Testing locally with localhost',
+              items: [
+                  `You are testing with the local callback: \`${callbackUrl}\`.`,
+                  'In Development mode, Meta often allows `http://localhost`, but many setups only accept the redirect URI after the **Website** platform and **Site URL** have been configured first.',
+                  'If Meta rejects the localhost callback at first, continue with the Website platform steps below, then return to the redirect URI field.',
+              ],
+          }
+        : null;
+
     return {
         title: 'Facebook Login setup guide',
-        intro: 'Create an app in **Meta for Developers**, enable **Facebook Login**, then copy **App ID**, **App Secret**, and the exact **Redirect URI**.',
+        intro: 'Create the app in **Meta for Developers**, add **Facebook Login**, configure the **Website** platform, then copy the exact **App ID**, **App Secret**, and environment-specific **Redirect URI**.',
         links: [
             {
                 label: 'Open Meta for Developers',
@@ -403,31 +510,58 @@ function buildFacebookDocs(language, callbackUrl) {
             },
         ],
         steps: [
+            ...(localWarningStep ? [localWarningStep] : []),
             {
-                title: '1. Prepare the environment',
+                title: '1. Create a new app from scratch',
                 items: [
-                    'Open **Meta for Developers**.',
-                    'Create or select the app for this website.',
-                    `The required **Valid OAuth Redirect URI** is: \`${callbackUrl}\`.`,
+                    'Open **Meta for Developers** from the link above.',
+                    'Click **Create App**.',
+                    'If Meta asks for a use case, choose the one that fits **Facebook Login**. If you just need to reach the dashboard quickly, **Other** is a valid starting point.',
+                    'If Meta shows an app type choice for end-user sign-in, choose the type that matches **Consumer**.',
+                    'Set a clear **Display Name** such as **OPAS Login**, **OPAS Facebook Login**, or **Test Login Localhost**.',
+                    'Enter the contact email.',
+                    'Leave the **Business** field empty if you are not using a business portfolio for this local test, then create the app.',
                 ],
             },
             {
-                title: '2. Create a Meta app',
+                title: '2. Add the Facebook Login product',
                 items: [
-                    'Open Meta for Developers and create an app for Facebook Login.',
-                    'Add the Facebook Login product to the app.',
+                    'In the app dashboard, find **Facebook Login** and click **Set up**.',
+                    'If Meta asks for a platform, choose **Web**.',
+                    `Keep the current website URL ready for the platform setup: \`${websiteUrl}\`.`,
                 ],
             },
             {
-                title: '3. Register the redirect URI',
+                title: '3. Add the Website platform in Settings > Basic',
                 items: [
-                    'Paste this exact value into **Valid OAuth Redirect URI**:',
+                    'Open **Settings** > **Basic** in the left menu.',
+                    'Scroll down and click **Add Platform**.',
+                    'Choose **Website**.',
+                    `Set **Site URL** to the current website URL: \`${websiteUrl}/\`.`,
+                    'Click **Save Changes**.',
+                ],
+            },
+            {
+                title: '4. Configure the Valid OAuth Redirect URI',
+                items: [
+                    'Open **Facebook Login** > **Settings**.',
+                    'Paste this exact value into **Valid OAuth Redirect URIs**:',
                     `\`${callbackUrl}\``,
+                    'If Meta refused the localhost callback earlier, the missing Website platform setup above is usually the reason.',
                     'If the URI is wrong, Facebook will reject the callback.',
+                    'Save the change.',
                 ],
             },
             {
-                title: '4. Copy values into this form',
+                title: '5. Check App Domains and Development mode',
+                items: [
+                    'In **Settings** > **Basic**, **App Domains** can stay empty or use `localhost` if Meta explicitly requires a value.',
+                    'While the app stays in **Development mode**, local testing with `http://localhost` is acceptable.',
+                    'You do not need **Live mode** just to test Facebook Login locally.',
+                ],
+            },
+            {
+                title: '6. Copy values into this form',
                 items: [
                     '**Client ID**: use the **App ID**.',
                     '**Client Secret**: use the **App Secret** from **App Settings** > **Basic**.',
@@ -435,18 +569,21 @@ function buildFacebookDocs(language, callbackUrl) {
                 ],
             },
             {
-                title: '5. Check the app mode',
+                title: '7. If login shows "App Not Active"',
                 items: [
-                    'If the app is still in development mode, only allowed accounts can test it.',
-                    'Review Meta publishing requirements if this login method will be used by public users.',
+                    'This usually means the app is still in **Development mode** and the Facebook account used for sign-in is not an **admin/developer/tester** of the app.',
+                    'The fastest test path is using the same Facebook account that created the app.',
+                    'If you want to test with another account, add that account under the app **Roles** as a **Developer** or **Tester**.',
+                    'The invited account must accept the invitation before it can test the login flow.',
                 ],
             },
             {
-                title: '6. Common issues',
+                title: '8. Common issues',
                 items: [
-                    'The redirect URL is rejected because the Valid OAuth Redirect URI was not registered correctly.',
-                    'Only internal testers can sign in because the app is still in development mode.',
+                    'Meta says the redirect URI is invalid: the **Website** platform or **Site URL** was not configured before saving the callback.',
+                    'Meta says **App Not Active**: the test account is not in the app **Roles**, or you are signed in with a different Facebook account.',
                     'The App Secret is wrong because it was copied incorrectly or changed in Meta.',
+                    'Only if Meta still refuses the local callback after all correct steps should you switch to a public dev domain or HTTPS tunnel and let the system regenerate the callback from `APP_URL`.',
                 ],
             },
         ],
@@ -462,6 +599,10 @@ function buildFacebookDocs(language, callbackUrl) {
             {
                 label: 'Redirect URI',
                 text: `Meta returns the user to this URL after sign-in: \`${callbackUrl}\`.`,
+            },
+            {
+                label: 'Website URL',
+                text: `Use \`${websiteUrl}/\` for **Site URL**. For **App Domains**, leave it empty or use \`localhost\` when testing locally if Meta requires a value.`,
             },
         ],
     };
@@ -567,14 +708,15 @@ function buildEmailDocs(language) {
  */
 export function getProviderDocs(providerKey, language, options = {}) {
     const callbackUrl = options.callbackUrl || 'Callback URL is not available yet.';
+    const websiteUrl = resolveWebsiteUrl(callbackUrl, language);
 
     switch (providerKey) {
         case 'google':
-            return buildGoogleDocs(language, callbackUrl);
+            return buildGoogleDocs(language, callbackUrl, websiteUrl);
         case 'github':
             return buildGithubDocs(language, callbackUrl);
         case 'facebook':
-            return buildFacebookDocs(language, callbackUrl);
+            return buildFacebookDocs(language, callbackUrl, websiteUrl);
         case 'email':
         default:
             return buildEmailDocs(language);

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php
@@ -55,6 +55,45 @@ class AuthProviderApiControllerTest extends TestCase
     }
 
     /**
+     * A configured Facebook provider should appear in the public login contract with backend-generated URLs.
+     */
+    public function test_it_returns_configured_facebook_provider_in_public_listing(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => 'https://example.com/auth/facebook/callback',
+                'button_text' => 'Continue with Facebook',
+                'scopes' => ['email', 'public_profile'],
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        $response = $this->getJson(route('api.auth.providers.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.key', 'email')
+            ->assertJsonPath('data.1.key', 'facebook')
+            ->assertJsonPath('data.1.display_name', 'Facebook')
+            ->assertJsonPath(
+                'data.1.metadata.redirect_url',
+                route('api.auth.providers.redirect', ['key' => 'facebook']),
+            )
+            ->assertJsonPath(
+                'data.1.metadata.callback_url',
+                route('api.auth.providers.callback', ['key' => 'facebook']),
+            )
+            ->assertJsonMissingPath('data.1.secret_config')
+            ->assertJsonMissingPath('data.1.metadata.client_secret');
+    }
+
+    /**
      * Public provider ordering should follow the configured backend sort order.
      */
     public function test_it_keeps_public_provider_ordering_from_backend_configuration(): void
@@ -105,6 +144,28 @@ class AuthProviderApiControllerTest extends TestCase
             'enabled' => true,
             'public_config' => [
                 'client_id' => 'google-client-id',
+            ],
+            'secret_config' => [],
+        ]);
+
+        $response = $this->getJson(route('api.auth.providers.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.key', 'email');
+    }
+
+    /**
+     * Incomplete Facebook providers must stay hidden even when an admin has toggled them on.
+     */
+    public function test_it_hides_enabled_but_incomplete_facebook_provider(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
             ],
             'secret_config' => [],
         ]);

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php
@@ -43,6 +43,31 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * Ready Facebook providers should redirect users to the Facebook authorization endpoint.
+     *
+     * @return void
+     */
+    public function test_facebook_redirect_sends_user_to_provider_authorization_url(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'facebook']));
+
+        $response->assertRedirect();
+        $this->assertStringStartsWith('https://www.facebook.com/v23.0/dialog/oauth?', $response->headers->get('Location', ''));
+    }
+
+    /**
      * A successful Google callback should sign the user in and persist the linked identity.
      *
      * @return void
@@ -105,6 +130,66 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * A successful Facebook callback should sign the user in and persist the linked identity.
+     *
+     * @return void
+     */
+    public function test_facebook_callback_logs_user_in_and_persists_identity(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://graph.facebook.com/v23.0/oauth/access_token' => Http::response([
+                'access_token' => 'facebook-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://graph.facebook.com/me?fields=id,name,email' => Http::response([
+                'id' => 'facebook-user-1',
+                'email' => 'facebook@example.com',
+                'name' => 'Facebook User',
+            ]),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.facebook' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'facebook',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'facebook@example.com',
+            'name' => 'Facebook User',
+        ]);
+        $this->assertDatabaseHas('user_auth_identities', [
+            'provider_key' => 'facebook',
+            'provider_user_id' => 'facebook-user-1',
+            'provider_email' => 'facebook@example.com',
+        ]);
+
+        $meResponse = $this->getJson(route('api.auth.me'));
+
+        $meResponse->assertOk()
+            ->assertJsonPath('data.email', 'facebook@example.com')
+            ->assertJsonPath('data.current_sign_in_provider.key', 'facebook')
+            ->assertJsonPath('data.current_sign_in_provider.display_name', 'Facebook')
+            ->assertJsonPath('data.current_sign_in_provider.icon', 'facebook');
+    }
+
+    /**
      * Disabled providers must not expose a working OAuth redirect entrypoint.
      *
      * @return void
@@ -124,6 +209,51 @@ class AuthProviderOAuthApiControllerTest extends TestCase
         ]);
 
         $response = $this->get(route('api.auth.providers.redirect', ['key' => 'google']));
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Disabled Facebook providers must not expose a working OAuth redirect entrypoint.
+     *
+     * @return void
+     */
+    public function test_facebook_redirect_returns_not_found_when_provider_is_disabled(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => false,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'facebook']));
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Facebook redirect should stay unavailable when the provider is enabled without complete config.
+     *
+     * @return void
+     */
+    public function test_facebook_redirect_returns_not_found_when_provider_configuration_is_incomplete(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+            ],
+            'secret_config' => [],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'facebook']));
 
         $response->assertNotFound();
     }
@@ -157,6 +287,45 @@ class AuthProviderOAuthApiControllerTest extends TestCase
             ->withSession(['auth.oauth_state.google' => 'state-123'])
             ->get(route('api.auth.providers.callback', [
                 'key' => 'google',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirectContains('/login?auth_error=');
+        $this->assertGuest();
+    }
+
+    /**
+     * Facebook token exchange failures should return safely to the login screen.
+     *
+     * @return void
+     */
+    public function test_facebook_callback_redirects_back_to_login_when_token_exchange_fails(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://graph.facebook.com/v23.0/oauth/access_token' => Http::response([
+                'error' => [
+                    'message' => 'Invalid verification code format.',
+                ],
+            ], 400),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.facebook' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'facebook',
                 'state' => 'state-123',
                 'code' => 'oauth-code-123',
             ]));
@@ -222,6 +391,52 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * Facebook callbacks must fail safely when the provider does not return an email address.
+     *
+     * @return void
+     */
+    public function test_facebook_callback_redirects_back_to_login_when_provider_email_is_missing(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://graph.facebook.com/v23.0/oauth/access_token' => Http::response([
+                'access_token' => 'facebook-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://graph.facebook.com/me?fields=id,name,email' => Http::response([
+                'id' => 'facebook-user-1',
+                'name' => 'Facebook User',
+            ]),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.facebook' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'facebook',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirectContains('/login?auth_error=');
+        $this->assertGuest();
+        $this->assertDatabaseMissing('user_auth_identities', [
+            'provider_key' => 'facebook',
+            'provider_user_id' => 'facebook-user-1',
+        ]);
+    }
+
+    /**
      * An authenticated email account should link Google onto the current account instead of switching users.
      *
      * @return void
@@ -279,6 +494,65 @@ class AuthProviderOAuthApiControllerTest extends TestCase
             'provider_key' => 'google',
             'provider_user_id' => 'google-user-1',
             'provider_email' => 'google@example.com',
+        ]);
+    }
+
+    /**
+     * An authenticated email account should link Facebook onto the current account instead of switching users.
+     *
+     * @return void
+     */
+    public function test_authenticated_user_can_link_facebook_to_the_current_account(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'facebook')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'facebook-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'facebook']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'facebook-secret',
+            ],
+        ]);
+
+        $user = User::factory()->create([
+            'email' => 'facebook@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://graph.facebook.com/v23.0/oauth/access_token' => Http::response([
+                'access_token' => 'facebook-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://graph.facebook.com/me?fields=id,name,email' => Http::response([
+                'id' => 'facebook-user-1',
+                'email' => 'facebook@example.com',
+                'name' => 'Facebook User',
+            ]),
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->withSession([
+                'auth.oauth_state.facebook' => 'state-123',
+                'auth.oauth_link.facebook' => $user->id,
+            ])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'facebook',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($user);
+        $this->assertDatabaseCount('users', 1);
+        $this->assertDatabaseHas('user_auth_identities', [
+            'user_id' => $user->id,
+            'provider_key' => 'facebook',
+            'provider_user_id' => 'facebook-user-1',
+            'provider_email' => 'facebook@example.com',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
This PR completes Facebook OAuth support coverage and setup guidance using the existing configurable auth provider architecture.

## What Changed
- added Facebook-specific feature tests for OAuth redirect and callback flows
- added Facebook coverage for:
  - enabled and configured success flow
  - disabled-provider access denial
  - incomplete configuration denial
  - token exchange failure handling
  - missing email failure handling
  - authenticated account linking flow
- added public provider listing tests for Facebook visibility/readiness behavior
- improved Facebook admin setup documentation to reflect Meta app setup requirements, Website platform setup, local callback behavior, and tester/role whitelisting
- added SPA cleanup for the Facebook `#_=_` redirect hash artifact after login

## Verification
Passed locally:
- `./vendor/bin/pint tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php`
- `php artisan test --filter=AuthProviderApiControllerTest`
- `php artisan test --filter=AuthProviderOAuthApiControllerTest`
- `php artisan test --filter=AdminAuthProviderApiControllerTest`
- `php artisan test --filter=AuthProviderConfigServiceTest`
- `npm run lint`
- `npm run build`
- `npm test -- --run resources/js/spa/features/auth/pages/LoginPage.test.jsx resources/js/spa/features/auth/pages/RegisterPage.test.jsx resources/js/spa/features/auth/pages/AccountSettingsPage.test.jsx resources/js/spa/features/auth/context/AuthContext.test.jsx`

## Notes
- Facebook login behavior was already working in practice, but this PR adds explicit regression coverage and clearer admin setup instructions.
- `phpstan` was not run for these test files because the current `phpstan.neon` scope excludes `tests/*`.

Closes #65
