### PR TITLE
Feat: complete GitHub auth provider flow

### DIFF
--- a/apps/laravel/app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php
+++ b/apps/laravel/app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php
@@ -74,14 +74,18 @@ abstract class AbstractOAuthAuthProviderDriver extends AbstractAuthProviderDrive
     public function publicMetadata(AuthProvider $provider): array
     {
         $config = $provider->public_config;
-
-        return [
-            'button_text' => $config['button_text'] ?? sprintf('Continue with %s', $provider->display_name),
+        $metadata = [
             'scopes' => $config['scopes'] ?? [],
             'pkce' => (bool) ($config['pkce'] ?? false),
             'redirect_url' => route('api.auth.providers.redirect', ['key' => $provider->key]),
             'callback_url' => route('api.auth.providers.callback', ['key' => $provider->key]),
         ];
+
+        if (is_string($config['button_text'] ?? null) && trim($config['button_text']) !== '') {
+            $metadata['button_text'] = $config['button_text'];
+        }
+
+        return $metadata;
     }
 
     /**

--- a/apps/laravel/resources/js/app.jsx
+++ b/apps/laravel/resources/js/app.jsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import App from './spa/App';
 import '../scss/app.scss';
 
+/**
+ * Mount the SPA into the Laravel blade entrypoint.
+ */
 ReactDOM.createRoot(document.getElementById('root')).render(
     <StrictMode>
         <App />

--- a/apps/laravel/resources/js/bootstrap.js
+++ b/apps/laravel/resources/js/bootstrap.js
@@ -1,4 +1,8 @@
 import axios from 'axios';
+
+/**
+ * Expose the default Axios client for legacy scripts that still rely on window globals.
+ */
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';

--- a/apps/laravel/resources/js/spa/App.jsx
+++ b/apps/laravel/resources/js/spa/App.jsx
@@ -38,6 +38,9 @@ function FacebookRedirectHashCleanup() {
     return null;
 }
 
+/**
+ * Render the top-level SPA providers and route tree.
+ */
 export default function App() {
     return (
         <BrowserRouter>

--- a/apps/laravel/resources/js/spa/components/icons/AppIcon.jsx
+++ b/apps/laravel/resources/js/spa/components/icons/AppIcon.jsx
@@ -206,6 +206,9 @@ function LinkIcon() {
     );
 }
 
+/**
+ * Register the SVG icon components available to the SPA.
+ */
 const icons = {
     dashboard: DashboardIcon,
     coins: CoinsIcon,
@@ -227,12 +230,28 @@ const icons = {
     link: LinkIcon,
 };
 
+/**
+ * Expose the supported icon names for admin-configurable icon fields.
+ */
 export const availableAppIcons = Object.freeze(Object.keys(icons));
 
+/**
+ * Check whether one icon name is registered in the shared icon set.
+ */
 export function hasAppIcon(name) {
     return typeof name === 'string' && Object.prototype.hasOwnProperty.call(icons, name);
 }
 
+/**
+ * Render one shared application icon by its registered name.
+ *
+ * @param {{
+ *   name: string,
+ *   filled?: boolean,
+ *   className?: string,
+ * }} props
+ * @returns {import('react').JSX.Element | null}
+ */
 export default function AppIcon({ name, filled = false, className = '' }) {
     const Icon = icons[name];
 

--- a/apps/laravel/resources/js/spa/components/layout/AdminShell.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/AdminShell.jsx
@@ -11,6 +11,11 @@ import AuthProvidersDashboardPage from '../../features/auth/pages/admin/AuthProv
 import AuthProviderAdminPage from '../../features/auth/pages/admin/AuthProviderAdminPage';
 import AdminUsersPage from '../../features/auth/pages/admin/AdminUsersPage';
 
+/**
+ * Render the admin console shell, navigation, and admin-only route tree.
+ *
+ * @returns {import('react').JSX.Element}
+ */
 export default function AdminShell() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/components/layout/AppShell.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/AppShell.jsx
@@ -11,6 +11,9 @@ import { useAuth } from '../../features/auth/context/AuthContext';
  *
  * Keeps layout concerns in one place: sidebar, sticky header,
  * footer, and mobile sidebar state.
+ *
+ * @param {{ children: import('react').ReactNode }} props
+ * @returns {import('react').JSX.Element}
  */
 export default function AppShell({ children }) {
     const [sidebarOpen, setSidebarOpen] = useState(false);

--- a/apps/laravel/resources/js/spa/components/layout/Footer.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/Footer.jsx
@@ -1,5 +1,11 @@
 import { useLanguage } from '../../features/i18n/context/LanguageContext';
 
+/**
+ * Render the shared footer used by workspace and admin shells.
+ *
+ * @param {{ variant?: 'workspace' | 'admin' }} props
+ * @returns {import('react').JSX.Element}
+ */
 export default function Footer({ variant = 'workspace' }) {
     const { t } = useLanguage();
 

--- a/apps/laravel/resources/js/spa/components/layout/Header.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/Header.jsx
@@ -5,6 +5,16 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../features/i18n/context/LanguageContext';
 import LanguageSelect from './LanguageSelect';
 
+/**
+ * Render the workspace header with account actions and route-specific titles.
+ *
+ * @param {{
+ *   title: string,
+ *   description?: string,
+ *   onToggleSidebar: () => void,
+ * }} props
+ * @returns {import('react').JSX.Element}
+ */
 export default function Header({ title, description, onToggleSidebar }) {
     const navigate = useNavigate();
     const { user, loading, logout, registerProviders } = useAuth();

--- a/apps/laravel/resources/js/spa/components/layout/LanguageSelect.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/LanguageSelect.jsx
@@ -1,5 +1,10 @@
 import { useLanguage } from '../../features/i18n/context/LanguageContext';
 
+/**
+ * Render the shared language switcher for the SPA.
+ *
+ * @returns {import('react').JSX.Element}
+ */
 export default function LanguageSelect() {
     const { language, setLanguage, t } = useLanguage();
 

--- a/apps/laravel/resources/js/spa/components/layout/Sidebar.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/Sidebar.jsx
@@ -4,6 +4,9 @@ import AppIcon from '../icons/AppIcon';
 import { useLanguage } from '../../features/i18n/context/LanguageContext';
 import { useAuth } from '../../features/auth/context/AuthContext';
 
+/**
+ * Render the primary sidebar navigation for workspace and admin entrypoints.
+ */
 export default function Sidebar() {
     const location = useLocation();
     const { t } = useLanguage();

--- a/apps/laravel/resources/js/spa/components/ui/ConfirmModal.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/ConfirmModal.jsx
@@ -1,6 +1,22 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+/**
+ * Render the shared confirmation modal used for destructive or important actions.
+ *
+ * @param {{
+ *   open: boolean,
+ *   eyebrow?: string,
+ *   title: string,
+ *   text: string,
+ *   confirmLabel: string,
+ *   cancelLabel: string,
+ *   tone?: 'primary' | 'danger',
+ *   onConfirm: () => void,
+ *   onCancel: () => void,
+ * }} props
+ * @returns {import('react').ReactPortal | import('react').JSX.Element | null}
+ */
 export default function ConfirmModal({
     open,
     eyebrow,

--- a/apps/laravel/resources/js/spa/components/ui/EmptyState.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/EmptyState.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render a simple empty-state message for data sets with no rows.
+ */
 export default function EmptyState({ text = 'No data available.' }) {
     return (
         <div className="app-empty-state">

--- a/apps/laravel/resources/js/spa/components/ui/ErrorState.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/ErrorState.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render a shared error message surface.
+ */
 export default function ErrorState({ text = 'Something went wrong.' }) {
     return (
         <div className="app-feedback app-feedback--error">

--- a/apps/laravel/resources/js/spa/components/ui/LoadingState.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/LoadingState.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render a shared loading placeholder with a short status label.
+ */
 export default function LoadingState({ text = 'Loading...' }) {
     return (
         <div className="app-feedback app-feedback--loading">

--- a/apps/laravel/resources/js/spa/components/ui/MetricCard.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/MetricCard.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render one highlighted metric card with an optional hint and tone.
+ */
 export default function MetricCard({ label, value, hint, tone = 'sky' }) {
     return (
         <article className={`app-metric app-metric--${tone}`}>

--- a/apps/laravel/resources/js/spa/components/ui/PageHero.jsx
+++ b/apps/laravel/resources/js/spa/components/ui/PageHero.jsx
@@ -1,3 +1,16 @@
+/**
+ * Render the shared page hero used by workspace and admin feature screens.
+ *
+ * @param {{
+ *   eyebrow?: string,
+ *   title: string,
+ *   text?: string,
+ *   actions?: import('react').ReactNode,
+ *   aside?: import('react').ReactNode,
+ *   children?: import('react').ReactNode,
+ * }} props
+ * @returns {import('react').JSX.Element}
+ */
 export default function PageHero({ eyebrow, title, text, actions, aside, children }) {
     return (
         <section className="app-hero">

--- a/apps/laravel/resources/js/spa/config/navigation.js
+++ b/apps/laravel/resources/js/spa/config/navigation.js
@@ -1,3 +1,25 @@
+/**
+ * @typedef {{
+ *   labelKey: string,
+ *   href: string,
+ *   icon: string,
+ *   activePrefixes?: string[],
+ *   adminOnly?: boolean,
+ * }} NavigationItem
+ */
+
+/**
+ * @typedef {{
+ *   labelKey: string,
+ *   items: NavigationItem[],
+ * }} NavigationSection
+ */
+
+/**
+ * Define the sidebar navigation contract for workspace and admin routes.
+ *
+ * @type {NavigationSection[]}
+ */
 export const navigation = [
     {
         labelKey: 'nav.workspace',

--- a/apps/laravel/resources/js/spa/features/auth/components/AuthProviderField.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/AuthProviderField.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render one labeled auth-provider field with shared help and error states.
+ */
 export default function AuthProviderField({
     label,
     required = false,

--- a/apps/laravel/resources/js/spa/features/auth/components/AuthProviderOptions.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/AuthProviderOptions.jsx
@@ -1,5 +1,8 @@
 import { renderPublicAuthProvider } from '../lib/publicAuthProviderRenderers';
 
+/**
+ * Render the public auth-provider actions available for one page context.
+ */
 export default function AuthProviderOptions({ providers, action, t }) {
     if (providers.length === 0) {
         return null;

--- a/apps/laravel/resources/js/spa/features/auth/components/AuthShowcase.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/AuthShowcase.jsx
@@ -1,3 +1,6 @@
+/**
+ * Render the shared marketing panel used across auth entry screens.
+ */
 export default function AuthShowcase({ eyebrow, title, text, tags = [], cta, imageSrc }) {
     return (
         <article className="app-auth-showcase">

--- a/apps/laravel/resources/js/spa/features/auth/components/RedirectAuthProviderButton.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/RedirectAuthProviderButton.jsx
@@ -1,10 +1,16 @@
 import AppIcon, { hasAppIcon } from '../../../components/icons/AppIcon';
 import { getProviderActionText, getRedirectUrl } from '../lib/publicAuthProviders';
 
+/**
+ * Build the provider-specific button class used by redirect sign-in actions.
+ */
 function buildOauthButtonClass(key) {
     return `app-button app-social-button app-social-button--${key}`;
 }
 
+/**
+ * Render one OAuth redirect button for login, registration, or account linking.
+ */
 export default function RedirectAuthProviderButton({ provider, action, t }) {
     const actionText = getProviderActionText(provider, action, t);
 

--- a/apps/laravel/resources/js/spa/features/auth/components/UnsupportedAuthProviderNotice.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/components/UnsupportedAuthProviderNotice.jsx
@@ -1,5 +1,8 @@
 import { getProviderActionText } from '../lib/publicAuthProviders';
 
+/**
+ * Show a safe fallback notice when the frontend cannot render a provider interaction yet.
+ */
 export default function UnsupportedAuthProviderNotice({ provider, action, t }) {
     return (
         <div className="app-provider-note" role="status">

--- a/apps/laravel/resources/js/spa/features/auth/context/AuthContext.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/context/AuthContext.jsx
@@ -2,8 +2,66 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import api from '../../../lib/api';
 import { getLinkableProviders, getProvidersForCapability } from '../lib/publicAuthProviders';
 
+/**
+ * @typedef {{
+ *   key: string,
+ *   display_name?: string,
+ *   type?: string,
+ *   icon?: string | null,
+ *   capabilities?: Record<string, boolean>,
+ *   metadata?: Record<string, unknown>,
+ * }} AuthRuntimeProvider
+ */
+
+/**
+ * @typedef {{
+ *   key: string,
+ *   display_name?: string,
+ *   icon?: string | null,
+ * }} AuthLinkedProvider
+ */
+
+/**
+ * @typedef {{
+ *   id?: number,
+ *   name?: string,
+ *   email?: string,
+ *   role?: string,
+ *   role_label?: string,
+ *   linked_providers?: AuthLinkedProvider[],
+ *   current_sign_in_provider?: AuthLinkedProvider | null,
+ * }} AuthUser
+ */
+
+/**
+ * @typedef {{
+ *   user: AuthUser | null,
+ *   loading: boolean,
+ *   authProviders: AuthRuntimeProvider[],
+ *   providersLoading: boolean,
+ *   providersError: string | null,
+ *   isAuthenticated: boolean,
+ *   hasEmailLogin: boolean,
+ *   loginProviders: AuthRuntimeProvider[],
+ *   registerProviders: AuthRuntimeProvider[],
+ *   linkableProviders: AuthRuntimeProvider[],
+ *   login: (payload: Record<string, unknown>) => Promise<any>,
+ *   register: (payload: Record<string, unknown>) => Promise<any>,
+ *   logout: () => Promise<void>,
+ *   refreshUser: () => Promise<void>,
+ *   refreshAuthProviders: () => Promise<void>,
+ * }} AuthContextValue
+ */
+
+/** @type {import('react').Context<AuthContextValue | null>} */
 const AuthContext = createContext(null);
 
+/**
+ * Provide the authenticated user and runtime auth-provider contracts to the SPA.
+ *
+ * @param {{ children: import('react').ReactNode }} props
+ * @returns {import('react').JSX.Element}
+ */
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -99,6 +157,11 @@ export function AuthProvider({ children }) {
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
+/**
+ * Read the shared auth context and fail fast when it is missing.
+ *
+ * @returns {AuthContextValue}
+ */
 export function useAuth() {
     const context = useContext(AuthContext);
 

--- a/apps/laravel/resources/js/spa/features/auth/lib/passwordValidation.js
+++ b/apps/laravel/resources/js/spa/features/auth/lib/passwordValidation.js
@@ -1,3 +1,6 @@
+/**
+ * Evaluate the password rules enforced by the auth registration and reset flows.
+ */
 export function getPasswordChecks(password) {
     const value = String(password ?? '');
 
@@ -10,12 +13,18 @@ export function getPasswordChecks(password) {
     };
 }
 
+/**
+ * Check whether a password satisfies every required rule.
+ */
 export function isStrongPassword(password) {
     const checks = getPasswordChecks(password);
 
     return Object.values(checks).every(Boolean);
 }
 
+/**
+ * Return the translation keys for password rules the current value still fails.
+ */
 export function getMissingPasswordRuleKeys(password) {
     const checks = getPasswordChecks(password);
 

--- a/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviderRenderers.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviderRenderers.jsx
@@ -2,12 +2,18 @@ import RedirectAuthProviderButton from '../components/RedirectAuthProviderButton
 import UnsupportedAuthProviderNotice from '../components/UnsupportedAuthProviderNotice';
 import { isRedirectProvider } from './publicAuthProviders';
 
+/**
+ * Render one redirect-capable provider with the shared OAuth button component.
+ */
 function renderRedirectProvider(provider, action, t) {
     return (
         <RedirectAuthProviderButton key={provider.key} provider={provider} action={action} t={t} />
     );
 }
 
+/**
+ * Render a safe placeholder when the provider type is not yet supported by the SPA.
+ */
 function renderUnsupportedProvider(provider, action, t) {
     return (
         <UnsupportedAuthProviderNotice
@@ -23,6 +29,9 @@ const providerRenderers = Object.freeze({
     oauth2: renderRedirectProvider,
 });
 
+/**
+ * Resolve the correct public auth-provider renderer for the current provider contract.
+ */
 export function renderPublicAuthProvider(provider, action, t) {
     const renderer = providerRenderers[provider.type];
 

--- a/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.js
+++ b/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.js
@@ -1,7 +1,44 @@
+/**
+ * @typedef {{
+ *   key: string,
+ *   display_name?: string,
+ *   type?: string,
+ *   icon?: string | null,
+ *   capabilities?: Record<string, boolean>,
+ *   metadata?: Record<string, unknown>,
+ * }} PublicAuthProvider
+ */
+
+/**
+ * @typedef {{
+ *   key?: string,
+ * }} LinkedProviderRef
+ */
+
+/**
+ * @typedef {{
+ *   linked_providers?: LinkedProviderRef[],
+ * }} LinkedProviderOwner
+ */
+
+/**
+ * Check whether a provider exposes one frontend capability flag.
+ *
+ * @param {PublicAuthProvider | null | undefined} provider
+ * @param {string} capability
+ * @returns {boolean}
+ */
 export function hasProviderCapability(provider, capability) {
     return Boolean(provider?.capabilities?.[capability]);
 }
 
+/**
+ * Filter one provider list down to entries that support the requested capability.
+ *
+ * @param {PublicAuthProvider[] | null | undefined} providers
+ * @param {string} capability
+ * @returns {PublicAuthProvider[]}
+ */
 export function getProvidersForCapability(providers, capability) {
     if (!Array.isArray(providers)) {
         return [];
@@ -10,6 +47,12 @@ export function getProvidersForCapability(providers, capability) {
     return providers.filter((provider) => hasProviderCapability(provider, capability));
 }
 
+/**
+ * Extract the linked provider keys already attached to the current account.
+ *
+ * @param {LinkedProviderOwner | null | undefined} user
+ * @returns {string[]}
+ */
 export function getLinkedProviderKeys(user) {
     if (!Array.isArray(user?.linked_providers)) {
         return [];
@@ -20,14 +63,32 @@ export function getLinkedProviderKeys(user) {
         .filter((key) => typeof key === 'string' && key.trim() !== '');
 }
 
+/**
+ * Distinguish the built-in password flow from redirect-based providers.
+ *
+ * @param {PublicAuthProvider | null | undefined} provider
+ * @returns {boolean}
+ */
 export function isPasswordProvider(provider) {
     return provider?.type === 'password' || provider?.capabilities?.supports_password === true;
 }
 
+/**
+ * Identify providers that leave the SPA for OAuth-style sign-in.
+ *
+ * @param {PublicAuthProvider | null | undefined} provider
+ * @returns {boolean}
+ */
 export function isRedirectProvider(provider) {
     return provider?.capabilities?.requires_redirect === true || provider?.type === 'oauth2';
 }
 
+/**
+ * Resolve the email/password provider used to render the inline auth form.
+ *
+ * @param {PublicAuthProvider[]} providers
+ * @returns {PublicAuthProvider | null}
+ */
 export function getPasswordFormProvider(providers) {
     return (
         providers.find((provider) => provider.key === 'email' && isPasswordProvider(provider)) ??
@@ -35,10 +96,24 @@ export function getPasswordFormProvider(providers) {
     );
 }
 
+/**
+ * Return providers that should render as secondary actions outside the password form.
+ *
+ * @param {PublicAuthProvider[]} providers
+ * @param {PublicAuthProvider | null} formProvider
+ * @returns {PublicAuthProvider[]}
+ */
 export function getNonFormProviders(providers, formProvider) {
     return providers.filter((provider) => provider.key !== formProvider?.key);
 }
 
+/**
+ * Return redirect providers that can still be linked to the current account.
+ *
+ * @param {PublicAuthProvider[]} providers
+ * @param {LinkedProviderOwner | null | undefined} user
+ * @returns {PublicAuthProvider[]}
+ */
 export function getLinkableProviders(providers, user) {
     const linkedProviderKeys = new Set(getLinkedProviderKeys(user));
 
@@ -47,17 +122,51 @@ export function getLinkableProviders(providers, user) {
     );
 }
 
+/**
+ * Resolve the backend redirect endpoint for one public provider button.
+ *
+ * @param {PublicAuthProvider} provider
+ * @returns {string}
+ */
 export function getRedirectUrl(provider) {
     return provider?.metadata?.redirect_url ?? `/api/auth/providers/${provider.key}/redirect`;
 }
 
-export function getProviderActionText(provider, action, t) {
-    if (action === 'register' && typeof provider?.metadata?.register_button_text === 'string') {
-        return provider.metadata.register_button_text;
+/**
+ * Treat blank custom button labels as absent so provider-aware fallbacks remain usable.
+ *
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+function resolveConfiguredActionText(value) {
+    if (typeof value !== 'string') {
+        return null;
     }
 
-    if (action === 'login' && typeof provider?.metadata?.button_text === 'string') {
-        return provider.metadata.button_text;
+    return value.trim() === '' ? null : value;
+}
+
+/**
+ * Build the provider action label shown on login and registration buttons.
+ *
+ * @param {PublicAuthProvider} provider
+ * @param {'login' | 'register'} action
+ * @param {(key: string) => string} t
+ * @returns {string}
+ */
+export function getProviderActionText(provider, action, t) {
+    const configuredRegisterText = resolveConfiguredActionText(
+        provider?.metadata?.register_button_text,
+    );
+
+    if (action === 'register' && configuredRegisterText !== null) {
+        return configuredRegisterText;
+    }
+
+    const configuredLoginText = resolveConfiguredActionText(provider?.metadata?.button_text);
+
+    if (action === 'login' && configuredLoginText !== null) {
+        return configuredLoginText;
     }
 
     const prefix =

--- a/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.test.js
+++ b/apps/laravel/resources/js/spa/features/auth/lib/publicAuthProviders.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getProviderActionText } from './publicAuthProviders';
+
+describe('getProviderActionText', () => {
+    /**
+     * Protect provider-aware fallback labels when admins leave custom button text blank.
+     */
+    it('falls back to a provider-specific login label when button text is blank', () => {
+        const label = getProviderActionText(
+            {
+                display_name: 'GitHub',
+                metadata: {
+                    button_text: '   ',
+                },
+            },
+            'login',
+            vi.fn(
+                (key) =>
+                    ({
+                        'auth.continueWithProvider': 'Continue with',
+                        'auth.registerWithProvider': 'Register with',
+                    })[key] ?? key,
+            ),
+        );
+
+        expect(label).toBe('Continue with GitHub');
+    });
+});

--- a/apps/laravel/resources/js/spa/features/auth/pages/AccountSettingsPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/AccountSettingsPage.jsx
@@ -9,6 +9,9 @@ import { useAuth } from '../context/AuthContext';
 import { getRedirectUrl } from '../lib/publicAuthProviders';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 
+/**
+ * Collapse backend validation payloads into the first useful account-settings message.
+ */
 function firstErrorMessage(requestError, fallbackMessage) {
     const errors = requestError?.response?.data?.errors;
 
@@ -23,6 +26,9 @@ function firstErrorMessage(requestError, fallbackMessage) {
     return requestError?.response?.data?.message || fallbackMessage;
 }
 
+/**
+ * Render profile and linked-provider management for the authenticated account.
+ */
 export default function AccountSettingsPage() {
     const navigate = useNavigate();
     const { t } = useLanguage();

--- a/apps/laravel/resources/js/spa/features/auth/pages/ForgotPasswordPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/ForgotPasswordPage.jsx
@@ -6,6 +6,9 @@ import ErrorState from '../../../components/ui/ErrorState';
 import AuthShowcase from '../components/AuthShowcase';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 
+/**
+ * Render the password-reset request screen for email-based recovery.
+ */
 export default function ForgotPasswordPage() {
     const { t } = useLanguage();
     const [email, setEmail] = useState('');

--- a/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/LoginPage.jsx
@@ -9,6 +9,9 @@ import { getNonFormProviders, getPasswordFormProvider } from '../lib/publicAuthP
 import { useLanguage } from '../../i18n/context/LanguageContext';
 import LanguageSelect from '../../../components/layout/LanguageSelect';
 
+/**
+ * Render the login screen with dynamic provider discovery and email fallback handling.
+ */
 export default function LoginPage() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/RegisterPage.jsx
@@ -10,6 +10,9 @@ import { getNonFormProviders, getPasswordFormProvider } from '../lib/publicAuthP
 import { useLanguage } from '../../i18n/context/LanguageContext';
 import LanguageSelect from '../../../components/layout/LanguageSelect';
 
+/**
+ * Render the registration screen with password rules and provider-aware fallback actions.
+ */
 export default function RegisterPage() {
     const navigate = useNavigate();
     const { register, registerProviders, providersLoading, providersError } = useAuth();

--- a/apps/laravel/resources/js/spa/features/auth/pages/ResetPasswordPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/ResetPasswordPage.jsx
@@ -8,6 +8,9 @@ import SensitiveInput from '../components/SensitiveInput';
 import { getMissingPasswordRuleKeys, isStrongPassword } from '../lib/passwordValidation';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 
+/**
+ * Render the password reset completion screen for one reset token.
+ */
 export default function ResetPasswordPage() {
     const { token = '' } = useParams();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/auth/pages/VerifyEmailPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/VerifyEmailPage.jsx
@@ -6,6 +6,9 @@ import ErrorState from '../../../components/ui/ErrorState';
 import AuthShowcase from '../components/AuthShowcase';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 
+/**
+ * Render the email verification screen for code entry and resend actions.
+ */
 export default function VerifyEmailPage() {
     const location = useLocation();
     const { t } = useLanguage();

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/AdminUserEditModal.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/AdminUserEditModal.jsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import AppIcon from '../../../../components/icons/AppIcon';
 
+/**
+ * Render the admin modal used to edit one user profile and reset that account password.
+ */
 export default function AdminUserEditModal({
     open,
     t,

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/AdminUsersPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/AdminUsersPage.jsx
@@ -19,6 +19,9 @@ const EMPTY_PAGINATION = {
     to: 0,
 };
 
+/**
+ * Build editable admin-form rows keyed by user id.
+ */
 function buildUserForms(users) {
     return Object.fromEntries(
         users.map((user) => [
@@ -32,6 +35,9 @@ function buildUserForms(users) {
     );
 }
 
+/**
+ * Collapse backend validation payloads into the first useful admin-user message.
+ */
 function firstErrorMessage(requestError, fallbackMessage) {
     const errors = requestError?.response?.data?.errors;
 
@@ -46,6 +52,9 @@ function firstErrorMessage(requestError, fallbackMessage) {
     return requestError?.response?.data?.message || fallbackMessage;
 }
 
+/**
+ * Detect whether one editable admin-user row diverged from its initial state.
+ */
 function hasRowChanged(form, initialForm) {
     if (!form || !initialForm) {
         return false;
@@ -54,10 +63,16 @@ function hasRowChanged(form, initialForm) {
     return form.name.trim() !== initialForm.name.trim() || form.role !== initialForm.role;
 }
 
+/**
+ * Check whether one admin-user row contains the minimum values required to save.
+ */
 function isRowSubmittable(form) {
     return Boolean(form?.name?.trim()) && Boolean(form?.role);
 }
 
+/**
+ * Build a compact pagination model centered around the current page.
+ */
 function buildPaginationItems(currentPage, lastPage) {
     if (lastPage <= 1) {
         return [1];
@@ -70,6 +85,9 @@ function buildPaginationItems(currentPage, lastPage) {
         .sort((left, right) => left - right);
 }
 
+/**
+ * Render the admin user-management screen with edit, delete, reset, and search actions.
+ */
 export default function AdminUsersPage() {
     const { t } = useLanguage();
     const { user: currentUser } = useAuth();

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/AuthProviderAdminPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/AuthProviderAdminPage.jsx
@@ -22,6 +22,9 @@ import {
 } from './authProviderAdminForm.helpers';
 import { getProviderDocs } from './providerDocs';
 
+/**
+ * Prefer server-side validation messages and only reveal client-side issues after touch.
+ */
 function getFieldError(fieldIssues, serverErrors, fieldTouches, key) {
     if (serverErrors[key]?.[0]) {
         return serverErrors[key][0];
@@ -34,10 +37,16 @@ function getFieldError(fieldIssues, serverErrors, fieldTouches, key) {
     return fieldIssues[key] || '';
 }
 
+/**
+ * Build stable input names for provider settings fields and secret inputs.
+ */
 function buildProviderInputName(providerKey, fieldKey, bucket = 'base') {
     return `auth-provider-${providerKey}-${bucket}-${fieldKey}`;
 }
 
+/**
+ * Render the lightweight inline markdown tokens used by provider setup docs.
+ */
 function renderInlineRichText(text) {
     const tokens = String(text)
         .split(/(`[^`]+`|\*\*[^*]+\*\*)/g)
@@ -56,6 +65,9 @@ function renderInlineRichText(text) {
     });
 }
 
+/**
+ * Render the admin provider detail page that manages auth-provider config and readiness.
+ */
 export default function AuthProviderAdminPage() {
     const { key = 'email' } = useParams();
     const { user, loading: authLoading } = useAuth();
@@ -163,10 +175,19 @@ export default function AuthProviderAdminPage() {
         : selectedProvider.ready
           ? 'app-status-pill--muted'
           : 'app-status-pill--warning';
+    const visibilityLabel =
+        form.visibility === 'public'
+            ? t('adminAuth.visibility.public')
+            : form.visibility === 'hidden'
+              ? t('adminAuth.visibility.hidden')
+              : t('adminAuth.visibility.adminOnly');
     const providerDocs = getProviderDocs(selectedProvider.key, language, {
         callbackUrl: selectedProvider.metadata?.callback_url ?? null,
     });
 
+    /**
+     * Clear one backend validation error after the admin edits the related field again.
+     */
     const clearProviderFieldError = (fieldKey) => {
         setServerErrors((current) => {
             const nextProviderErrors = { ...(current[selectedProvider.key] ?? {}) };
@@ -179,6 +200,9 @@ export default function AuthProviderAdminPage() {
         });
     };
 
+    /**
+     * Record user interaction so client-side validation errors appear intentionally.
+     */
     const markFieldTouched = (fieldKey) => {
         setTouchedFields((current) => ({
             ...current,
@@ -189,6 +213,9 @@ export default function AuthProviderAdminPage() {
         }));
     };
 
+    /**
+     * Update one top-level provider field and mark the current provider form dirty.
+     */
     const updateForm = (field, value) => {
         setForms((current) => ({
             ...current,
@@ -205,6 +232,9 @@ export default function AuthProviderAdminPage() {
         setFlash(null);
     };
 
+    /**
+     * Update one nested public or secret config field for the selected provider.
+     */
     const updateConfigField = (bucket, field, value) => {
         setForms((current) => ({
             ...current,
@@ -224,6 +254,9 @@ export default function AuthProviderAdminPage() {
         setFlash(null);
     };
 
+    /**
+     * Track whether one masked secret field is currently in edit mode.
+     */
     const updateSecretEditState = (fieldKey, editing) => {
         setSecretEditState((current) => ({
             ...current,
@@ -231,6 +264,9 @@ export default function AuthProviderAdminPage() {
         }));
     };
 
+    /**
+     * Persist the selected provider and replace local form state with the saved response.
+     */
     const performSaveProvider = async () => {
         setSavingKey(selectedProvider.key);
         setFlash({
@@ -351,7 +387,7 @@ export default function AuthProviderAdminPage() {
                     </span>
                     <span className="app-chip">{selectedProvider.type}</span>
                     <span className="app-chip">
-                        {t('adminAuth.visibility.chip')} {form.visibility}
+                        {t('adminAuth.visibility.chip')} {visibilityLabel}
                     </span>
                 </div>
 
@@ -697,6 +733,7 @@ export default function AuthProviderAdminPage() {
                                         const meta = buildFieldMeta(t, field, {
                                             callbackUrl:
                                                 selectedProvider.metadata?.callback_url ?? null,
+                                            providerDisplayName: selectedProvider.display_name,
                                         });
                                         const errorMessage = getFieldError(
                                             fieldIssues,

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/AuthProvidersDashboardPage.jsx
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/AuthProvidersDashboardPage.jsx
@@ -7,6 +7,9 @@ import PageHero from '../../../../components/ui/PageHero';
 import api from '../../../../lib/api';
 import { useLanguage } from '../../../i18n/context/LanguageContext';
 
+/**
+ * Render the provider dashboard used to jump into one auth-provider config screen.
+ */
 export default function AuthProvidersDashboardPage() {
     const { t } = useLanguage();
     const [providers, setProviders] = useState([]);

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/authProviderAdminForm.helpers.js
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/authProviderAdminForm.helpers.js
@@ -1,5 +1,43 @@
 import { availableAppIcons, hasAppIcon } from '../../../../components/icons/AppIcon';
 
+/**
+ * @typedef {{
+ *   key: string,
+ *   enabled?: boolean,
+ *   display_name?: string,
+ *   icon?: string | null,
+ *   sort_order?: number,
+ *   visibility?: string,
+ *   email_verification_mode?: string | null,
+ *   public_config?: Record<string, unknown>,
+ *   required_public_keys?: string[],
+ *   required_secret_keys?: string[],
+ *   secret_status?: Record<string, boolean>,
+ * }} AuthProviderAdminRecord
+ */
+
+/**
+ * @typedef {{
+ *   enabled: boolean,
+ *   display_name: string,
+ *   icon: string,
+ *   sort_order: string,
+ *   visibility: string,
+ *   email_verification_mode: string,
+ *   public_config: Record<string, string>,
+ *   secret_config: Record<string, string>,
+ * }} AuthProviderAdminForm
+ */
+
+/**
+ * @typedef {{
+ *   label: string,
+ *   description: string,
+ *   placeholder: string,
+ *   span: 'half' | 'full',
+ * }} AuthProviderFieldMeta
+ */
+
 const staticFieldMeta = {
     client_id: { key: 'client_id', span: 'half' },
     redirect_uri: { key: 'redirect_uri', span: 'full' },
@@ -14,6 +52,12 @@ const staticBaseMeta = {
     sort_order: { key: 'sort_order', span: 'half' },
 };
 
+/**
+ * Normalize mixed form values into text input values the admin screen can render.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
 function toTextValue(value) {
     if (value === null || value === undefined) {
         return '';
@@ -26,12 +70,42 @@ function toTextValue(value) {
     return String(value);
 }
 
+/**
+ * Build a provider-aware button text placeholder instead of reusing a Google-specific example.
+ *
+ * @param {(key: string) => string} t
+ * @param {string | null | undefined} providerDisplayName
+ * @returns {string}
+ */
+function buildProviderButtonTextPlaceholder(t, providerDisplayName) {
+    const prefix = t('auth.continueWithProvider');
+    const displayName = String(providerDisplayName ?? '').trim();
+
+    if (displayName === '' || prefix === 'auth.continueWithProvider') {
+        return t('adminAuth.fields.button_text.placeholder');
+    }
+
+    return `${prefix} ${displayName}`;
+}
+
+/**
+ * Keep object-key comparisons deterministic before dirty-checking form snapshots.
+ *
+ * @param {Record<string, string>} input
+ * @returns {Record<string, string>}
+ */
 function sortEntries(input) {
     return Object.fromEntries(
         Object.entries(input).sort(([left], [right]) => left.localeCompare(right)),
     );
 }
 
+/**
+ * Reduce one provider form to a stable shape for unsaved-change detection.
+ *
+ * @param {AuthProviderAdminForm} form
+ * @returns {Omit<AuthProviderAdminForm, 'secret_config'>}
+ */
 function normalizeFormSnapshot(form) {
     return {
         enabled: Boolean(form.enabled),
@@ -51,6 +125,12 @@ function normalizeFormSnapshot(form) {
     };
 }
 
+/**
+ * Build the editable admin form state from one provider payload.
+ *
+ * @param {AuthProviderAdminRecord} provider
+ * @returns {AuthProviderAdminForm}
+ */
 export function buildInitialForm(provider) {
     const requiredPublicKeys = provider.required_public_keys ?? [];
     const requiredSecretKeys = provider.required_secret_keys ?? [];
@@ -77,6 +157,14 @@ export function buildInitialForm(provider) {
     };
 }
 
+/**
+ * Resolve metadata for one provider-specific config field in the admin form.
+ *
+ * @param {(key: string) => string} t
+ * @param {string} field
+ * @param {{ callbackUrl?: string | null, providerDisplayName?: string | null }} [options]
+ * @returns {AuthProviderFieldMeta}
+ */
 export function buildFieldMeta(t, field, options = {}) {
     const meta = staticFieldMeta[field];
 
@@ -92,7 +180,9 @@ export function buildFieldMeta(t, field, options = {}) {
     const placeholder =
         field === 'redirect_uri' && options.callbackUrl
             ? options.callbackUrl
-            : t(`adminAuth.fields.${meta.key}.placeholder`);
+            : field === 'button_text'
+              ? buildProviderButtonTextPlaceholder(t, options.providerDisplayName)
+              : t(`adminAuth.fields.${meta.key}.placeholder`);
 
     return {
         label: t(`adminAuth.fields.${meta.key}.label`),
@@ -102,6 +192,13 @@ export function buildFieldMeta(t, field, options = {}) {
     };
 }
 
+/**
+ * Resolve metadata for one base provider field in the admin form.
+ *
+ * @param {(key: string) => string} t
+ * @param {string} field
+ * @returns {AuthProviderFieldMeta}
+ */
 export function buildBaseMeta(t, field) {
     const meta = staticBaseMeta[field];
 
@@ -113,6 +210,13 @@ export function buildBaseMeta(t, field) {
     };
 }
 
+/**
+ * Prefer provider-specific admin summaries and fall back to the generic copy when missing.
+ *
+ * @param {AuthProviderAdminRecord} provider
+ * @param {(key: string) => string} t
+ * @returns {string}
+ */
 export function getProviderSummary(provider, t) {
     return t(`adminAuth.providers.${provider.key}.summary`) !==
         `adminAuth.providers.${provider.key}.summary`
@@ -120,6 +224,14 @@ export function getProviderSummary(provider, t) {
         : t('adminAuth.providers.default.summary');
 }
 
+/**
+ * Collect client-side validation issues before the admin submits a provider form.
+ *
+ * @param {AuthProviderAdminRecord} provider
+ * @param {AuthProviderAdminForm} form
+ * @param {(key: string) => string} t
+ * @returns {Record<string, string>}
+ */
 export function getFieldIssues(provider, form, t) {
     const issues = {};
 
@@ -170,16 +282,42 @@ export function getFieldIssues(provider, form, t) {
     return issues;
 }
 
+/**
+ * Expose the supported icon names for the provider icon picker.
+ *
+ * @returns {string[]}
+ */
 export function getAvailableIconNames() {
     return availableAppIcons;
 }
 
+/**
+ * Flatten validation message maps into one deduplicatable list for summary display.
+ *
+ * @param {Record<string, string | string[] | undefined>} errors
+ * @returns {string[]}
+ */
 export function flattenMessages(errors) {
     return Object.values(errors)
         .flatMap((value) => (Array.isArray(value) ? value : [value]))
         .filter(Boolean);
 }
 
+/**
+ * Build the API payload for one provider update, including normalized scopes.
+ *
+ * @param {AuthProviderAdminForm} form
+ * @returns {{
+ *   enabled: boolean,
+ *   display_name: string,
+ *   icon: string | null,
+ *   sort_order: number,
+ *   visibility: string,
+ *   email_verification_mode: string | null,
+ *   public_config: Record<string, string | string[]>,
+ *   secret_config: Record<string, string>,
+ * }}
+ */
 export function buildProviderPayload(form) {
     const publicConfig = Object.fromEntries(
         Object.entries(form.public_config).filter(([, value]) => value !== ''),
@@ -208,6 +346,13 @@ export function buildProviderPayload(form) {
     };
 }
 
+/**
+ * Detect whether the admin form diverged from its last saved provider snapshot.
+ *
+ * @param {AuthProviderAdminForm} form
+ * @param {AuthProviderAdminForm} initialForm
+ * @returns {boolean}
+ */
 export function isProviderFormDirty(form, initialForm) {
     const hasSecretUpdates = Object.values(form.secret_config ?? {}).some(
         (value) => String(value ?? '').trim() !== '',

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/authProviderAdminForm.helpers.test.js
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/authProviderAdminForm.helpers.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildFieldMeta } from './authProviderAdminForm.helpers';
+
+describe('buildFieldMeta', () => {
+    /**
+     * Keep the admin placeholder aligned with the provider being edited.
+     */
+    it('builds a provider-specific button text placeholder', () => {
+        const meta = buildFieldMeta(
+            vi.fn(
+                (key) =>
+                    ({
+                        'auth.continueWithProvider': 'Continue with',
+                        'adminAuth.fields.button_text.label': 'Login button text',
+                        'adminAuth.fields.button_text.description':
+                            'Text shown on the login button.',
+                        'adminAuth.fields.button_text.placeholder': 'Example: Continue with Google',
+                    })[key] ?? key,
+            ),
+            'button_text',
+            { providerDisplayName: 'Facebook' },
+        );
+
+        expect(meta.placeholder).toBe('Continue with Facebook');
+    });
+});

--- a/apps/laravel/resources/js/spa/features/auth/pages/admin/providerDocs.js
+++ b/apps/laravel/resources/js/spa/features/auth/pages/admin/providerDocs.js
@@ -1,3 +1,32 @@
+/**
+ * @typedef {{ label: string, url: string }} ProviderDocLink
+ */
+
+/**
+ * @typedef {{ title: string, items: string[] }} ProviderDocStep
+ */
+
+/**
+ * @typedef {{ label: string, text: string }} ProviderDocField
+ */
+
+/**
+ * @typedef {{
+ *   title: string,
+ *   intro: string,
+ *   links: ProviderDocLink[],
+ *   steps: ProviderDocStep[],
+ *   fields: ProviderDocField[],
+ * }} ProviderDocs
+ */
+
+/**
+ * Resolve the current website origin from a callback URL for provider setup instructions.
+ *
+ * @param {string} callbackUrl
+ * @param {string} language
+ * @returns {string}
+ */
 function resolveWebsiteUrl(callbackUrl, language) {
     try {
         return new URL(callbackUrl).origin;
@@ -6,6 +35,12 @@ function resolveWebsiteUrl(callbackUrl, language) {
     }
 }
 
+/**
+ * Detect localhost-style callback URLs so setup docs can warn about local quirks.
+ *
+ * @param {string} callbackUrl
+ * @returns {boolean}
+ */
 function isLocalCallbackUrl(callbackUrl) {
     try {
         const parsedUrl = new URL(callbackUrl);
@@ -16,6 +51,14 @@ function isLocalCallbackUrl(callbackUrl) {
     }
 }
 
+/**
+ * Build the Google provider setup guide in the active admin language.
+ *
+ * @param {string} language
+ * @param {string} callbackUrl
+ * @param {string} websiteUrl
+ * @returns {ProviderDocs}
+ */
 function buildGoogleDocs(language, callbackUrl, websiteUrl) {
     if (language === 'vi') {
         return {
@@ -212,6 +255,13 @@ function buildGoogleDocs(language, callbackUrl, websiteUrl) {
     };
 }
 
+/**
+ * Build the GitHub provider setup guide in the active admin language.
+ *
+ * @param {string} language
+ * @param {string} callbackUrl
+ * @returns {ProviderDocs}
+ */
 function buildGithubDocs(language, callbackUrl) {
     if (language === 'vi') {
         return {
@@ -358,6 +408,14 @@ function buildGithubDocs(language, callbackUrl) {
     };
 }
 
+/**
+ * Build the Facebook provider setup guide in the active admin language.
+ *
+ * @param {string} language
+ * @param {string} callbackUrl
+ * @param {string} websiteUrl
+ * @returns {ProviderDocs}
+ */
 function buildFacebookDocs(language, callbackUrl, websiteUrl) {
     const isLocalCallback = isLocalCallbackUrl(callbackUrl);
 
@@ -608,6 +666,12 @@ function buildFacebookDocs(language, callbackUrl, websiteUrl) {
     };
 }
 
+/**
+ * Build the email provider setup guide in the active admin language.
+ *
+ * @param {string} language
+ * @returns {ProviderDocs}
+ */
 function buildEmailDocs(language) {
     if (language === 'vi') {
         return {
@@ -698,13 +762,7 @@ function buildEmailDocs(language) {
  * @param {string} providerKey
  * @param {'en'|'vi'} language
  * @param {{ callbackUrl?: string | null }} options
- * @returns {{
- *   title: string,
- *   intro: string,
- *   links: Array<{label: string, url: string}>,
- *   steps: Array<{title: string, items: string[]}>,
- *   fields: Array<{label: string, text: string}>
- * }}
+ * @returns {ProviderDocs}
  */
 export function getProviderDocs(providerKey, language, options = {}) {
     const callbackUrl = options.callbackUrl || 'Callback URL is not available yet.';

--- a/apps/laravel/resources/js/spa/features/coins/pages/AlertEditPage.jsx
+++ b/apps/laravel/resources/js/spa/features/coins/pages/AlertEditPage.jsx
@@ -5,6 +5,9 @@ import PageHero from '../../../components/ui/PageHero';
 import { useAuth } from '../../auth/context/AuthContext';
 import api from '../../../lib/api';
 
+/**
+ * Render the edit screen for one coin price-alert rule.
+ */
 export default function AlertEditPage() {
     const { id } = useParams();
     const navigate = useNavigate();

--- a/apps/laravel/resources/js/spa/features/coins/pages/AlertsPage.jsx
+++ b/apps/laravel/resources/js/spa/features/coins/pages/AlertsPage.jsx
@@ -8,6 +8,9 @@ import PageHero from '../../../components/ui/PageHero';
 import { useAuth } from '../../auth/context/AuthContext';
 import api from '../../../lib/api';
 
+/**
+ * Render the price-alert list with quick toggle and edit actions.
+ */
 export default function AlertsPage() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/coins/pages/CoinDetailPage.jsx
+++ b/apps/laravel/resources/js/spa/features/coins/pages/CoinDetailPage.jsx
@@ -5,6 +5,9 @@ import LoadingState from '../../../components/ui/LoadingState';
 import PageHero from '../../../components/ui/PageHero';
 import api from '../../../lib/api';
 
+/**
+ * Render the detail view for one monitored coin symbol.
+ */
 export default function CoinDetailPage() {
     const { symbol } = useParams();
     const [coin, setCoin] = useState(null);

--- a/apps/laravel/resources/js/spa/features/coins/pages/CoinsPage.jsx
+++ b/apps/laravel/resources/js/spa/features/coins/pages/CoinsPage.jsx
@@ -18,6 +18,9 @@ const money = new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 3,
 });
 
+/**
+ * Render the main coin-monitor workspace with favorites and market summaries.
+ */
 export default function CoinsPage() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/coins/pages/KeywordsPage.jsx
+++ b/apps/laravel/resources/js/spa/features/coins/pages/KeywordsPage.jsx
@@ -8,6 +8,9 @@ import PageHero from '../../../components/ui/PageHero';
 import { useAuth } from '../../auth/context/AuthContext';
 import api from '../../../lib/api';
 
+/**
+ * Render keyword and tag management for coin-content automation inputs.
+ */
 export default function KeywordsPage() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/dashboard/pages/DashboardPage.jsx
+++ b/apps/laravel/resources/js/spa/features/dashboard/pages/DashboardPage.jsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../../i18n/context/LanguageContext';
 
+/**
+ * Render the workspace landing page with navigation into the main tools.
+ */
 export default function DashboardPage() {
     const { t } = useLanguage();
 

--- a/apps/laravel/resources/js/spa/features/i18n/context/LanguageContext.jsx
+++ b/apps/laravel/resources/js/spa/features/i18n/context/LanguageContext.jsx
@@ -2,12 +2,34 @@ import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { messages } from '../messages';
 
 const STORAGE_KEY = 'opas.language';
+/**
+ * @typedef {{
+ *   language: string,
+ *   setLanguage: import('react').Dispatch<import('react').SetStateAction<string>>,
+ *   t: (path: string) => string,
+ * }} LanguageContextValue
+ */
+
+/** @type {import('react').Context<LanguageContextValue | null>} */
 const LanguageContext = createContext(null);
 
+/**
+ * Resolve one nested translation path from the locale message tree.
+ *
+ * @param {string} locale
+ * @param {string} path
+ * @returns {unknown}
+ */
 function resolveMessage(locale, path) {
     return path.split('.').reduce((value, key) => value?.[key], messages[locale]);
 }
 
+/**
+ * Provide the active language and translation helper to the SPA.
+ *
+ * @param {{ children: import('react').ReactNode }} props
+ * @returns {import('react').JSX.Element}
+ */
 export function LanguageProvider({ children }) {
     const [language, setLanguage] = useState(() => {
         if (typeof window === 'undefined') {
@@ -34,6 +56,11 @@ export function LanguageProvider({ children }) {
     return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
 }
 
+/**
+ * Read the shared language context and fail fast when it is missing.
+ *
+ * @returns {LanguageContextValue}
+ */
 export function useLanguage() {
     const context = useContext(LanguageContext);
 

--- a/apps/laravel/resources/js/spa/features/i18n/messages.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages.js
@@ -1,6 +1,9 @@
 import { enMessages } from './messages/en';
 import { viMessages } from './messages/vi';
 
+/**
+ * Register the locale message catalogs available to the SPA.
+ */
 export const messages = {
     en: enMessages,
     vi: viMessages,

--- a/apps/laravel/resources/js/spa/features/i18n/messages/en.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/en.js
@@ -1,3 +1,6 @@
+/**
+ * Define the English locale catalog for the SPA.
+ */
 export const enMessages = {
     common: {
         home: 'Home',
@@ -288,18 +291,18 @@ export const enMessages = {
         },
         visibility: {
             label: 'Visibility',
-            public: 'public - show on login screen',
-            hidden: 'hidden - hide from login screen',
-            adminOnly: 'admin_only - internal use only',
+            public: 'Public - show on login screen',
+            hidden: 'Hidden - hide from login screen',
+            adminOnly: 'Admin only - internal use only',
             chip: 'visibility:',
             help: 'Only providers with visibility set to public can appear on the public login screen.',
         },
         emailVerification: {
             label: 'Email verification policy',
-            inherit: 'inherit - use system default',
-            required: 'required - must verify',
-            optional: 'optional - allow without force',
-            disabled: 'disabled - turn off verification',
+            inherit: 'Inherit - use system default',
+            required: 'Required - must verify',
+            optional: 'Optional - allow without force',
+            disabled: 'Disabled - turn off verification',
             help: 'Use this to apply a separate email verification rule for this provider.',
             emailLockedHelp:
                 'Email registration always requires verification before the account can be used.',

--- a/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
@@ -1,3 +1,6 @@
+/**
+ * Define the Vietnamese locale catalog for the SPA.
+ */
 export const viMessages = {
     common: {
         home: 'Trang chủ',
@@ -291,18 +294,18 @@ export const viMessages = {
         },
         visibility: {
             label: 'Phạm vi hiển thị',
-            public: 'public - hiện ở trang đăng nhập',
-            hidden: 'hidden - ẩn khỏi trang đăng nhập',
-            adminOnly: 'admin_only - chỉ phục vụ nội bộ',
+            public: 'Public - hiện ở trang đăng nhập',
+            hidden: 'Hidden - ẩn khỏi trang đăng nhập',
+            adminOnly: 'Admin only - chỉ phục vụ nội bộ',
             chip: 'phạm vi:',
             help: 'Chỉ provider có visibility = public mới được phép xuất hiện ngoài màn hình đăng nhập.',
         },
         emailVerification: {
             label: 'Chính sách xác minh email',
-            inherit: 'inherit - dùng mặc định hệ thống',
-            required: 'required - bắt buộc',
-            optional: 'optional - tùy chọn',
-            disabled: 'disabled - tắt',
+            inherit: 'Inherit - dùng mặc định hệ thống',
+            required: 'Required - bắt buộc',
+            optional: 'Optional - tùy chọn',
+            disabled: 'Disabled - tắt',
             help: 'Dùng để áp dụng chính sách xác minh email riêng cho provider này.',
             emailLockedHelp:
                 'Đăng ký bằng email luôn bắt buộc xác minh trước khi tài khoản được sử dụng.',

--- a/apps/laravel/resources/js/spa/features/stocks/pages/StocksPage.jsx
+++ b/apps/laravel/resources/js/spa/features/stocks/pages/StocksPage.jsx
@@ -8,6 +8,9 @@ import PageHero from '../../../components/ui/PageHero';
 import { useAuth } from '../../auth/context/AuthContext';
 import api from '../../../lib/api';
 
+/**
+ * Render the stock-monitor workspace with search and favorites.
+ */
 export default function StocksPage() {
     const navigate = useNavigate();
     const location = useLocation();

--- a/apps/laravel/resources/js/spa/features/video-automation/pages/VideosPage.jsx
+++ b/apps/laravel/resources/js/spa/features/video-automation/pages/VideosPage.jsx
@@ -6,6 +6,9 @@ import MetricCard from '../../../components/ui/MetricCard';
 import PageHero from '../../../components/ui/PageHero';
 import api from '../../../lib/api';
 
+/**
+ * Render grouped trending-video sources for the automation workflow.
+ */
 export default function VideosPage() {
     const [groups, setGroups] = useState([]);
     const [loading, setLoading] = useState(true);

--- a/apps/laravel/resources/js/test/setup.js
+++ b/apps/laravel/resources/js/test/setup.js
@@ -1,1 +1,4 @@
+/**
+ * Register shared DOM matchers for Vitest component tests.
+ */
 import '@testing-library/jest-dom/vitest';

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php
@@ -68,6 +68,31 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * Ready GitHub providers should redirect users to the GitHub authorization endpoint.
+     *
+     * @return void
+     */
+    public function test_github_redirect_sends_user_to_provider_authorization_url(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'github']));
+
+        $response->assertRedirect();
+        $this->assertStringStartsWith('https://github.com/login/oauth/authorize?', $response->headers->get('Location', ''));
+    }
+
+    /**
      * A successful Google callback should sign the user in and persist the linked identity.
      *
      * @return void
@@ -190,6 +215,73 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * A successful GitHub callback should sign the user in and persist the linked identity.
+     *
+     * @return void
+     */
+    public function test_github_callback_logs_user_in_and_persists_identity(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://github.com/login/oauth/access_token' => Http::response([
+                'access_token' => 'github-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://api.github.com/user' => Http::response([
+                'id' => 9001,
+                'login' => 'octocat',
+                'name' => 'GitHub User',
+            ]),
+            'https://api.github.com/user/emails' => Http::response([
+                [
+                    'email' => 'github@example.com',
+                    'primary' => true,
+                    'verified' => true,
+                ],
+            ]),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.github' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'github',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticated();
+        $this->assertDatabaseHas('users', [
+            'email' => 'github@example.com',
+            'name' => 'GitHub User',
+        ]);
+        $this->assertDatabaseHas('user_auth_identities', [
+            'provider_key' => 'github',
+            'provider_user_id' => '9001',
+            'provider_email' => 'github@example.com',
+        ]);
+
+        $meResponse = $this->getJson(route('api.auth.me'));
+
+        $meResponse->assertOk()
+            ->assertJsonPath('data.email', 'github@example.com')
+            ->assertJsonPath('data.current_sign_in_provider.key', 'github')
+            ->assertJsonPath('data.current_sign_in_provider.display_name', 'GitHub')
+            ->assertJsonPath('data.current_sign_in_provider.icon', 'github');
+    }
+
+    /**
      * Disabled providers must not expose a working OAuth redirect entrypoint.
      *
      * @return void
@@ -238,6 +330,30 @@ class AuthProviderOAuthApiControllerTest extends TestCase
     }
 
     /**
+     * Disabled GitHub providers must not expose a working OAuth redirect entrypoint.
+     *
+     * @return void
+     */
+    public function test_github_redirect_returns_not_found_when_provider_is_disabled(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => false,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'github']));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * Facebook redirect should stay unavailable when the provider is enabled without complete config.
      *
      * @return void
@@ -254,6 +370,27 @@ class AuthProviderOAuthApiControllerTest extends TestCase
         ]);
 
         $response = $this->get(route('api.auth.providers.redirect', ['key' => 'facebook']));
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * GitHub redirect should stay unavailable when the provider is enabled without complete config.
+     *
+     * @return void
+     */
+    public function test_github_redirect_returns_not_found_when_provider_configuration_is_incomplete(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+            ],
+            'secret_config' => [],
+        ]);
+
+        $response = $this->get(route('api.auth.providers.redirect', ['key' => 'github']));
 
         $response->assertNotFound();
     }
@@ -326,6 +463,43 @@ class AuthProviderOAuthApiControllerTest extends TestCase
             ->withSession(['auth.oauth_state.facebook' => 'state-123'])
             ->get(route('api.auth.providers.callback', [
                 'key' => 'facebook',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirectContains('/login?auth_error=');
+        $this->assertGuest();
+    }
+
+    /**
+     * GitHub token exchange failures should return safely to the login screen.
+     *
+     * @return void
+     */
+    public function test_github_callback_redirects_back_to_login_when_token_exchange_fails(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://github.com/login/oauth/access_token' => Http::response([
+                'error' => 'bad_verification_code',
+            ], 400),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.github' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'github',
                 'state' => 'state-123',
                 'code' => 'oauth-code-123',
             ]));
@@ -433,6 +607,61 @@ class AuthProviderOAuthApiControllerTest extends TestCase
         $this->assertDatabaseMissing('user_auth_identities', [
             'provider_key' => 'facebook',
             'provider_user_id' => 'facebook-user-1',
+        ]);
+    }
+
+    /**
+     * GitHub callbacks must fail safely when neither the profile nor the emails endpoint returns a primary email.
+     *
+     * @return void
+     */
+    public function test_github_callback_redirects_back_to_login_when_provider_email_is_missing(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        Http::fake([
+            'https://github.com/login/oauth/access_token' => Http::response([
+                'access_token' => 'github-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://api.github.com/user' => Http::response([
+                'id' => 'github-user-1',
+                'login' => 'octocat',
+                'name' => 'GitHub User',
+                'email' => null,
+            ]),
+            'https://api.github.com/user/emails' => Http::response([
+                [
+                    'email' => 'secondary@example.com',
+                    'primary' => false,
+                    'verified' => true,
+                ],
+            ]),
+        ]);
+
+        $response = $this
+            ->withSession(['auth.oauth_state.github' => 'state-123'])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'github',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirectContains('/login?auth_error=');
+        $this->assertGuest();
+        $this->assertDatabaseMissing('user_auth_identities', [
+            'provider_key' => 'github',
+            'provider_user_id' => 'github-user-1',
         ]);
     }
 
@@ -553,6 +782,72 @@ class AuthProviderOAuthApiControllerTest extends TestCase
             'provider_key' => 'facebook',
             'provider_user_id' => 'facebook-user-1',
             'provider_email' => 'facebook@example.com',
+        ]);
+    }
+
+    /**
+     * An authenticated email account should link GitHub onto the current account instead of switching users.
+     *
+     * @return void
+     */
+    public function test_authenticated_user_can_link_github_to_the_current_account(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'github')->firstOrFail();
+        $provider->update([
+            'enabled' => true,
+            'public_config' => [
+                'client_id' => 'github-client-id',
+                'redirect_uri' => route('api.auth.providers.callback', ['key' => 'github']),
+            ],
+            'secret_config' => [
+                'client_secret' => 'github-secret',
+            ],
+        ]);
+
+        $user = User::factory()->create([
+            'email' => 'github@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://github.com/login/oauth/access_token' => Http::response([
+                'access_token' => 'github-token-123',
+                'expires_in' => 3600,
+            ]),
+            'https://api.github.com/user' => Http::response([
+                'id' => 9001,
+                'login' => 'octocat',
+                'name' => 'GitHub User',
+            ]),
+            'https://api.github.com/user/emails' => Http::response([
+                [
+                    'email' => 'github@example.com',
+                    'primary' => true,
+                    'verified' => true,
+                ],
+            ]),
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->withSession([
+                'auth.oauth_state.github' => 'state-123',
+                'auth.oauth_link.github' => $user->id,
+            ])
+            ->get(route('api.auth.providers.callback', [
+                'key' => 'github',
+                'state' => 'state-123',
+                'code' => 'oauth-code-123',
+            ]));
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($user);
+        $this->assertDatabaseCount('users', 1);
+        $this->assertDatabaseHas('user_auth_identities', [
+            'user_id' => $user->id,
+            'provider_key' => 'github',
+            'provider_user_id' => '9001',
+            'provider_email' => 'github@example.com',
         ]);
     }
 }

--- a/docs/CODEGEN-RULES.md
+++ b/docs/CODEGEN-RULES.md
@@ -11,11 +11,11 @@ Read only the sections that match the task at hand:
 - [docs/rules/quality-rules.md](docs/rules/quality-rules.md)
   Use for method size, parameter count, typing, readability, data shaping, query efficiency, and maintainability heuristics.
 - [docs/rules/frontend-rules.md](docs/rules/frontend-rules.md)
-  Use for SPA visual design, layout systems, button/input/dropdown states, color usage, interaction behavior, accessibility, and frontend UX consistency.
+  Use for SPA visual design, layout systems, button/input/dropdown states, color usage, interaction behavior, accessibility, frontend UX consistency, and shared frontend architecture expectations.
 - [docs/rules/docblock-rules.md](docs/rules/docblock-rules.md)
-  Use for PHP docblock requirements in `app/` and documented test methods/helpers.
+  Use for PHP docblocks plus JSDoc requirements in `resources/js`, including shared frontend contracts, components, and test helpers.
 - [docs/rules/comment-rules.md](docs/rules/comment-rules.md)
-  Use when adding or reviewing code comments.
+  Use when adding or reviewing PHP comments, frontend JSDoc, and targeted inline comments.
 - [docs/rules/testing-rules.md](docs/rules/testing-rules.md)
   Use when adding or updating tests, including folder structure and coverage expectations.
 - [docs/rules/auth-provider-rules.md](docs/rules/auth-provider-rules.md)
@@ -39,6 +39,8 @@ Minimum reading path by task type:
   - `coding-rules.md`
   - `quality-rules.md`
   - `frontend-rules.md`
+  - `docblock-rules.md`
+  - `comment-rules.md`
   - `testing-rules.md`
   - `verification-rules.md`
 - Auth provider or login flow work:

--- a/docs/rules/comment-rules.md
+++ b/docs/rules/comment-rules.md
@@ -41,3 +41,12 @@ Comments should make code easier to maintain, not compensate for weak naming or 
 
 - First improve naming and structure.
 - Then add the smallest comment that explains the remaining non-obvious part.
+
+## Frontend Comment Rules
+
+- In `resources/js`, prefer JSDoc for reusable functions, components, contexts, config contracts, and entry modules, and reserve regular comments for non-obvious UI rules, backend-contract constraints, or provider-specific quirks.
+- In `resources/js`, use JSDoc as the primary documentation mechanism for exported functions and components instead of replacing that documentation with ad hoc inline comments.
+- Do not add comments above every React hook or state setter. Comment only the workflow rule that would otherwise be easy to misread.
+- When frontend logic mirrors a backend safety rule, say that explicitly in one short comment instead of narrating the branch line by line.
+- For formatting helpers, fallback label builders, and payload normalizers, add a short comment only if the function name and JSDoc still leave an important constraint implicit.
+- When a frontend contract is reused across helpers or contexts, prefer one local `@typedef` plus focused JSDoc over repeating vague inline comments on every consumer.

--- a/docs/rules/docblock-rules.md
+++ b/docs/rules/docblock-rules.md
@@ -7,6 +7,9 @@ Apply these rules to PHP code in `apps/laravel/app/`.
 When tests introduce helper methods, data builders, or non-trivial setup logic in `apps/laravel/tests/`,
 apply the same method-level documentation standards there as well.
 
+Apply the same documentation discipline to frontend code in `apps/laravel/resources/js/`
+using concise JSDoc blocks instead of PHP docblocks.
+
 ## Method Rules
 
 - Every public and protected PHP method in `app/` must have a docblock with a one-line summary.
@@ -16,6 +19,17 @@ apply the same method-level documentation standards there as well.
 - Array-shaped payloads must declare their array shape in `@param` or `@return` whenever practical.
 - PHPUnit test methods should include a concise summary docblock and `@return void`.
 - Test helper methods with parameters or non-trivial behavior must include `@param` and `@return`.
+- Every `export default function` in `resources/js` must have a concise JSDoc summary block.
+- Exported JS/React functions in `resources/js` that shape data, own UI/business branching, transform API payloads, provide reusable feature behavior, define a shared contract, or bootstrap app/runtime behavior must have a JSDoc block.
+- Non-exported JS/React helpers should also have a JSDoc block when they perform non-trivial normalization, fallback resolution, or rendering-related branching.
+- React components should always have a short JSDoc summary when exported, and should also document props with `@param` when the prop list is non-trivial.
+- Simple leaf callbacks, tiny inline render helpers, and obvious one-line utilities do not need JSDoc unless the surrounding file depends on them as a stable contract.
+- JS test helpers with non-trivial setup or reusable provider fixtures should have a short JSDoc block that explains the scenario they build.
+- Add `@returns` to frontend JSDoc when the function returns a non-obvious value, a reusable data contract, or a JSX element from a shared component.
+- Component JSDoc should include an explicit props shape when the component has more than 3 props, accepts function props, or exposes variant/tone/layout options.
+- Helper JSDoc should include parameter shapes when the helper consumes structured objects whose keys are part of the contract.
+- For shared contexts, prefer local `@typedef` contracts over generic `Record<string, any>` return shapes.
+- For shared config arrays or reusable payload builders, prefer named `@typedef` contracts when more than one field matters to consumers.
 
 ## Class-Level Rules
 
@@ -32,6 +46,10 @@ apply the same method-level documentation standards there as well.
 - Prefer imperative clarity over prose. One strong sentence is better than three weak ones.
 - Keep terminology consistent with the domain and the API contract.
 - In tests, summarize the business rule or scenario being protected instead of restating the test method name.
+- For JSDoc in frontend code, prefer a one-line summary plus `@param` or `@returns` only when they add clarity.
+- If TypeScript-style detail would repeat obvious runtime shapes, keep the JSDoc lighter instead of adding noise.
+- Prefer documenting the data contract or workflow rule over DOM mechanics.
+- For shared components and context providers, prefer documenting the props or return contract once in the JSDoc rather than scattering explanatory comments through the render body.
 
 ## Review Checklist
 
@@ -39,3 +57,7 @@ apply the same method-level documentation standards there as well.
 - Parameters reflect real runtime expectations.
 - `@return` matches the actual contract.
 - Complex arrays are typed clearly enough for maintenance and static analysis.
+- Frontend helpers with branching or normalization expose a clear JSDoc contract.
+- React components with feature orchestration have a short summary block.
+- Every exported frontend component/function has at least a summary JSDoc block.
+- Shared components with multiple props or callbacks document their props shape with `@param`.

--- a/docs/rules/frontend-rules.md
+++ b/docs/rules/frontend-rules.md
@@ -189,6 +189,8 @@ Use these rules whenever a task touches `resources/js/spa`, `resources/scss`, UI
 - Prefer feature-local helpers over duplicating formatting or provider logic across multiple screens.
 - SCSS should mirror feature intent. Reuse existing component classes when possible before adding more one-off variants.
 - Shared shell components such as `Header`, `Sidebar`, and `Footer` should accept explicit variants or props when admin and workspace need different presentation. Do not rely on accidental placement differences alone.
+- Shared frontend contracts should be documented close to the owning code with JSDoc or local `@typedef` shapes instead of being left implicit across multiple files.
+- Context hooks, config registries, shared payload builders, and shared render helpers should expose a readable documentation contract before they are reused broadly.
 
 ## Workspace Shell Rules
 

--- a/docs/rules/verification-rules.md
+++ b/docs/rules/verification-rules.md
@@ -5,6 +5,9 @@
 - Run `./vendor/bin/pint` on changed PHP files.
 - Run `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon` on changed PHP paths or the narrowest relevant runtime scope.
 - Run the narrowest relevant PHPUnit scope for the changed behavior.
+- For frontend changes in `apps/laravel/resources/js` or Vite-related assets, run the closest CI-equivalent command before closing the task:
+  - prefer `npm run ci` when the change touches shared frontend code, build output, routing, config, formatting-sensitive files, or multiple SPA areas
+  - at minimum include `npm run check` when the task is intentionally narrower and you are explicitly not validating the bundle
 
 ## Pre-Commit And Pre-Push Workflow
 
@@ -14,11 +17,13 @@
   - `./vendor/bin/pint` on changed PHP files
   - `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon ...`
   - `php artisan test ...` for the narrowest relevant backend scope
-  - `npm run lint` for SPA changes
+  - `npm run check` for SPA changes so both `eslint` and `prettier --check` run before push
   - `npm run build` when the frontend bundle, Vite config, or shared UI shell changed
   - `npm test -- --run ...` for the narrowest relevant frontend/Vitest scope when React components or contexts changed
+  - `npm run ci` instead of separate frontend commands when you want parity with the CI pipeline or when the diff touches shared frontend code across multiple files
 - Before pushing a branch, re-run the narrowest set that proves the final staged diff is still green after the last edits.
 - If a task is large or cross-cutting, prefer collecting the exact commands and results in the PR or handoff note.
+- If CI uses a named wrapper command such as `npm run ci`, prefer documenting and running that exact command in addition to any narrower local checks that helped during development.
 
 ## Suggested Local Checklist
 
@@ -28,14 +33,16 @@
 - `./vendor/bin/pint ...`
 - `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon ...`
 - `php artisan test ...`
-- `npm run lint`
+- `npm run check`
 - `npm run build`
 - `npm test -- --run ...`
+- `npm run ci`
 - `git status --short`
 
 ## Failure Handling
 
 - Do not ignore formatter failures without fixing them or documenting the blocker.
 - Do not ignore static-analysis failures without fixing them or documenting the blocker.
+- Do not treat `eslint` as sufficient when the repository also enforces `prettier --check` in CI.
 - If a requested scope cannot be executed, report exactly what could not be run and why.
 - Prefer verifying the smallest relevant scope first, then expand only if the change radius justifies it.


### PR DESCRIPTION
## Summary
Complete GitHub login support using the existing configurable auth-provider architecture, and align the admin/frontend experience with the other providers.

## What changed
- added GitHub OAuth redirect and callback coverage to match Google/Facebook behavior
- completed GitHub account creation and account-linking flows from provider profile data
- enforced safe handling for disabled providers and incomplete GitHub configuration
- fixed provider button label fallback so each provider renders its own correct action text
- improved admin provider UX for visibility and email-verification labels
- expanded frontend JSDoc and documentation rules so shared contracts and components are documented consistently

## Verification
- `php artisan test tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php`
- `npm test -- --run resources/js/spa/features/auth/lib/publicAuthProviders.test.js resources/js/spa/features/auth/pages/admin/authProviderAdminForm.helpers.test.js resources/js/spa/features/auth/pages/LoginPage.test.jsx resources/js/spa/features/auth/pages/RegisterPage.test.jsx resources/js/spa/features/auth/pages/AccountSettingsPage.test.jsx`
- `./vendor/bin/pint --test app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon app/Auth/Drivers/AbstractOAuthAuthProviderDriver.php`
- `npx eslint resources/js`

## Notes
- existing custom `button_text` values stored in the database are still respected; only fallback/default behavior was corrected
- no known residual backend gaps remain for the GitHub provider flow within the issue scope

Closes #66
