### PR TITLE
OPAS-0067 [AUTH][ADMIN] Harden auth settings and verification security flows

### DIFF
--- a/apps/laravel/app/Http/Controllers/Api/AdminAuthProviderApiController.php
+++ b/apps/laravel/app/Http/Controllers/Api/AdminAuthProviderApiController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateAuthProviderRequest;
 use App\Http\Resources\AdminAuthProviderResource;
+use App\Models\User;
 use App\Services\Auth\AuthProviderConfigService;
 use App\Services\Auth\AuthProviderService;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -43,10 +44,12 @@ class AdminAuthProviderApiController extends Controller
         $resolved = $this->authProviderService->resolve($key);
 
         abort_if($resolved === null, 404);
+        $actor = $request->user();
 
         $provider = $this->authProviderConfigService->update(
             $resolved['provider'],
             $request->validated(),
+            $actor instanceof User ? $actor : null,
         );
 
         $next = $this->authProviderService->resolve($provider->key);

--- a/apps/laravel/app/Http/Requests/UpdateAuthProviderRequest.php
+++ b/apps/laravel/app/Http/Requests/UpdateAuthProviderRequest.php
@@ -9,6 +9,15 @@ use Illuminate\Validation\Rule;
 
 class UpdateAuthProviderRequest extends FormRequest
 {
+    private const ALLOWED_CAPABILITY_KEYS = [
+        'login',
+        'register',
+        'link_account',
+        'requires_redirect',
+        'supports_email_verification',
+        'supports_password',
+    ];
+
     private const ALLOWED_ICONS = [
         'dashboard',
         'coins',
@@ -23,6 +32,19 @@ class UpdateAuthProviderRequest extends FormRequest
         'github',
         'facebook',
         'heart',
+    ];
+
+    private const ALLOWED_PUBLIC_CONFIG_KEYS = [
+        'button_text',
+        'client_id',
+        'password_reset_enabled',
+        'pkce',
+        'redirect_uri',
+        'scopes',
+    ];
+
+    private const ALLOWED_SECRET_CONFIG_KEYS = [
+        'client_secret',
     ];
 
     /**
@@ -54,9 +76,23 @@ class UpdateAuthProviderRequest extends FormRequest
             'icon' => ['sometimes', 'nullable', 'string', 'max:100', Rule::in(self::ALLOWED_ICONS)],
             'sort_order' => ['sometimes', 'integer', 'min:0'],
             'visibility' => ['sometimes', 'string', Rule::in(['public', 'hidden', 'admin_only'])],
-            'capabilities' => ['sometimes', 'array'],
-            'public_config' => ['sometimes', 'array'],
-            'secret_config' => ['sometimes', 'array'],
+            'capabilities' => ['sometimes', 'array:'.implode(',', self::ALLOWED_CAPABILITY_KEYS)],
+            'capabilities.login' => ['sometimes', 'boolean'],
+            'capabilities.register' => ['sometimes', 'boolean'],
+            'capabilities.link_account' => ['sometimes', 'boolean'],
+            'capabilities.requires_redirect' => ['sometimes', 'boolean'],
+            'capabilities.supports_email_verification' => ['sometimes', 'boolean'],
+            'capabilities.supports_password' => ['sometimes', 'boolean'],
+            'public_config' => ['sometimes', 'array:'.implode(',', self::ALLOWED_PUBLIC_CONFIG_KEYS)],
+            'public_config.button_text' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'public_config.client_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'public_config.password_reset_enabled' => ['sometimes', 'boolean'],
+            'public_config.pkce' => ['sometimes', 'boolean'],
+            'public_config.redirect_uri' => ['sometimes', 'nullable', 'string', 'max:2048'],
+            'public_config.scopes' => ['sometimes', 'array'],
+            'public_config.scopes.*' => ['string', 'max:100'],
+            'secret_config' => ['sometimes', 'array:'.implode(',', self::ALLOWED_SECRET_CONFIG_KEYS)],
+            'secret_config.client_secret' => ['sometimes', 'nullable', 'string', 'max:2048'],
             'email_verification_mode' => [
                 'sometimes',
                 'nullable',

--- a/apps/laravel/app/Services/Auth/AuthProviderConfigService.php
+++ b/apps/laravel/app/Services/Auth/AuthProviderConfigService.php
@@ -6,6 +6,7 @@ namespace App\Services\Auth;
 
 use App\Auth\Contracts\AuthProviderDriverInterface;
 use App\Models\AuthProvider;
+use App\Models\User;
 use App\Repositories\Auth\Interfaces\AuthProviderRepositoryInterface;
 use Illuminate\Validation\ValidationException;
 
@@ -19,6 +20,7 @@ class AuthProviderConfigService
     public function __construct(
         private readonly AuthProviderRepositoryInterface $authProviderRepository,
         private readonly AuthProviderRegistry $authProviderRegistry,
+        private readonly AuthSecurityAuditService $authSecurityAuditService,
     ) {}
 
     /**
@@ -27,10 +29,12 @@ class AuthProviderConfigService
      *
      * @param  AuthProvider  $provider
      * @param  array<string, mixed>  $validated
+     * @param  User|null  $actor
      * @return AuthProvider
      */
-    public function update(AuthProvider $provider, array $validated): AuthProvider
+    public function update(AuthProvider $provider, array $validated, ?User $actor = null): AuthProvider
     {
+        $before = $actor === null ? null : clone $provider;
         $attributes = $validated;
 
         if ($provider->key === 'email') {
@@ -54,7 +58,19 @@ class AuthProviderConfigService
 
         $this->validateUpdate($provider, $attributes);
 
-        return $this->authProviderRepository->update($provider, $attributes);
+        $updatedProvider = $this->authProviderRepository->update($provider, $attributes);
+
+        if ($actor === null) {
+            return $updatedProvider;
+        }
+
+        if (! $before instanceof AuthProvider) {
+            return $updatedProvider;
+        }
+
+        $this->authSecurityAuditService->logProviderSettingsUpdated($actor, $before, $updatedProvider);
+
+        return $updatedProvider;
     }
 
     /**
@@ -74,6 +90,7 @@ class AuthProviderConfigService
 
         $errors = [];
         $enabled = (bool) ($attributes['enabled'] ?? $provider->enabled);
+        $capabilities = $this->normalizeConfigArray($attributes['capabilities'] ?? $provider->capabilities);
         $publicConfig = $this->normalizeConfigArray($attributes['public_config'] ?? $provider->public_config);
         $secretConfig = $this->normalizeConfigArray($attributes['secret_config'] ?? $provider->secret_config);
 
@@ -90,9 +107,41 @@ class AuthProviderConfigService
             $errors['enabled'] = ['At least one active login provider must remain enabled.'];
         }
 
+        if ($this->disablesLastWorkingLoginCapability($provider, $driver, $enabled, $capabilities)) {
+            $errors['capabilities.login'] = ['At least one active login provider must continue to support login.'];
+        }
+
         if ($errors !== []) {
             throw ValidationException::withMessages($errors);
         }
+    }
+
+    /**
+     * Prevent capability changes from removing the final working login path.
+     *
+     * @param  AuthProvider  $provider
+     * @param  AuthProviderDriverInterface  $driver
+     * @param  bool  $enabled
+     * @param  array<string, mixed>  $capabilities
+     * @return bool
+     */
+    private function disablesLastWorkingLoginCapability(
+        AuthProvider $provider,
+        AuthProviderDriverInterface $driver,
+        bool $enabled,
+        array $capabilities,
+    ): bool {
+        if (! $provider->enabled || ! $driver->isReady($provider)) {
+            return false;
+        }
+
+        $currentSupportsLogin = (bool) ($provider->capabilities['login'] ?? false);
+        $nextSupportsLogin = (bool) ($capabilities['login'] ?? false);
+
+        return $enabled
+            && $currentSupportsLogin
+            && ! $nextSupportsLogin
+            && ! $this->hasAnotherActiveLoginProvider($provider);
     }
 
     /**

--- a/apps/laravel/app/Services/Auth/AuthSecurityAuditService.php
+++ b/apps/laravel/app/Services/Auth/AuthSecurityAuditService.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Auth;
+
+use App\Models\AuthProvider;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+class AuthSecurityAuditService
+{
+    /**
+     * Log a structured audit event for successful admin auth provider changes.
+     *
+     * @param  User  $actor
+     * @param  AuthProvider  $before
+     * @param  AuthProvider  $after
+     * @return void
+     */
+    public function logProviderSettingsUpdated(User $actor, AuthProvider $before, AuthProvider $after): void
+    {
+        $changes = $this->buildProviderChangeSet($before, $after);
+
+        if (! $this->hasProviderChanges($changes)) {
+            return;
+        }
+
+        Log::info('security.auth_provider_settings_updated', [
+            'actor_user_id' => $actor->id,
+            'provider_key' => $after->key,
+            ...$changes,
+        ]);
+    }
+
+    /**
+     * Log whether a verification resend request issued a fresh code.
+     *
+     * @param  string  $email
+     * @param  User|null  $user
+     * @param  bool  $codeIssued
+     * @return void
+     */
+    public function logVerificationResendRequested(string $email, ?User $user, bool $codeIssued): void
+    {
+        Log::info('security.auth_verification_resend_requested', [
+            'email_hash' => $this->hashEmail($email),
+            'target_user_id' => $user?->id,
+            'code_issued' => $codeIssued,
+        ]);
+    }
+
+    /**
+     * Log the outcome of one verification code submission.
+     *
+     * @param  string  $email
+     * @param  string  $status
+     * @param  User|null  $user
+     * @return void
+     */
+    public function logVerificationCodeChecked(string $email, string $status, ?User $user): void
+    {
+        Log::info('security.auth_verification_code_checked', [
+            'email_hash' => $this->hashEmail($email),
+            'target_user_id' => $user?->id,
+            'status' => $status,
+        ]);
+    }
+
+    /**
+     * Build a safe audit diff without logging secret values or provider payload contents.
+     *
+     * @param  AuthProvider  $before
+     * @param  AuthProvider  $after
+     * @return array{
+     *     changed_attributes:array<string, array{from:mixed,to:mixed}>,
+     *     changed_capability_keys:list<string>,
+     *     changed_public_config_keys:list<string>,
+     *     changed_secret_config_keys:list<string>
+     * }
+     */
+    private function buildProviderChangeSet(AuthProvider $before, AuthProvider $after): array
+    {
+        $attributeChanges = [];
+
+        foreach (['enabled', 'display_name', 'icon', 'sort_order', 'visibility', 'email_verification_mode'] as $key) {
+            if ($before->{$key} === $after->{$key}) {
+                continue;
+            }
+
+            $attributeChanges[$key] = [
+                'from' => $before->{$key},
+                'to' => $after->{$key},
+            ];
+        }
+
+        return [
+            'changed_attributes' => $attributeChanges,
+            'changed_capability_keys' => $this->resolveChangedKeys(
+                $this->normalizeArray($before->capabilities),
+                $this->normalizeArray($after->capabilities),
+            ),
+            'changed_public_config_keys' => $this->resolveChangedKeys(
+                $this->normalizeArray($before->public_config),
+                $this->normalizeArray($after->public_config),
+            ),
+            'changed_secret_config_keys' => $this->resolveChangedKeys(
+                $this->normalizeArray($before->secret_config),
+                $this->normalizeArray($after->secret_config),
+            ),
+        ];
+    }
+
+    /**
+     * Determine whether a provider diff contains any auditable changes.
+     *
+     * @param  array{
+     *     changed_attributes:array<string, array{from:mixed,to:mixed}>,
+     *     changed_capability_keys:list<string>,
+     *     changed_public_config_keys:list<string>,
+     *     changed_secret_config_keys:list<string>
+     * }  $changes
+     * @return bool
+     */
+    private function hasProviderChanges(array $changes): bool
+    {
+        return $changes['changed_attributes'] !== []
+            || $changes['changed_capability_keys'] !== []
+            || $changes['changed_public_config_keys'] !== []
+            || $changes['changed_secret_config_keys'] !== [];
+    }
+
+    /**
+     * Return the list of keys whose normalized values changed between snapshots.
+     *
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     * @return list<string>
+     */
+    private function resolveChangedKeys(array $before, array $after): array
+    {
+        $keys = array_unique([
+            ...array_keys($before),
+            ...array_keys($after),
+        ]);
+
+        sort($keys);
+
+        $changedKeys = [];
+
+        foreach ($keys as $key) {
+            $beforeValue = $this->normalizeValueForComparison($before[$key] ?? null);
+            $afterValue = $this->normalizeValueForComparison($after[$key] ?? null);
+
+            if ($beforeValue === $afterValue) {
+                continue;
+            }
+
+            $changedKeys[] = $key;
+        }
+
+        return $changedKeys;
+    }
+
+    /**
+     * Normalize a provider config array into a predictable string-keyed shape.
+     *
+     * @param  mixed  $value
+     * @return array<string, mixed>
+     */
+    private function normalizeArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($value as $key => $item) {
+            if (! is_string($key)) {
+                continue;
+            }
+
+            $normalized[$key] = $item;
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * Normalize nested values before comparing audit snapshots.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    private function normalizeValueForComparison(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            $normalized = array_map(
+                fn (mixed $item): mixed => $this->normalizeValueForComparison($item),
+                $value,
+            );
+
+            sort($normalized);
+
+            return $normalized;
+        }
+
+        $normalized = [];
+
+        foreach ($value as $key => $item) {
+            $normalized[(string) $key] = $this->normalizeValueForComparison($item);
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * Hash a user-supplied email so logs stay correlated without leaking raw addresses.
+     *
+     * @param  string  $email
+     * @return string
+     */
+    private function hashEmail(string $email): string
+    {
+        return hash('sha256', strtolower(trim($email)));
+    }
+}

--- a/apps/laravel/app/Services/Auth/EmailVerificationService.php
+++ b/apps/laravel/app/Services/Auth/EmailVerificationService.php
@@ -18,6 +18,7 @@ class EmailVerificationService
     public function __construct(
         private readonly EmailVerificationCodeRepositoryInterface $emailVerificationCodeRepository,
         private readonly UserRepositoryInterface $userRepository,
+        private readonly AuthSecurityAuditService $authSecurityAuditService,
     ) {}
 
     /**
@@ -45,17 +46,23 @@ class EmailVerificationService
      * Re-issue a verification code for the matching unverified account.
      *
      * @param  string  $email
-     * @return void
+     * @return string
      */
-    public function resendCode(string $email): void
+    public function resendCode(string $email): string
     {
         $user = $this->userRepository->findByEmail($email);
 
         if (! $user instanceof User || $user->hasVerifiedEmail()) {
-            return;
+            $this->authSecurityAuditService->logVerificationResendRequested($email, $user, false);
+
+            return 'ignored';
         }
 
         $this->sendCode($user);
+
+        $this->authSecurityAuditService->logVerificationResendRequested($email, $user, true);
+
+        return 'sent';
     }
 
     /**
@@ -70,51 +77,33 @@ class EmailVerificationService
         $user = $this->userRepository->findByEmail($email);
 
         if (! $user instanceof User) {
-            return [
-                'status' => 'invalid',
-                'user' => null,
-            ];
+            return $this->buildVerificationResult($email, 'invalid', null);
         }
 
         if ($user->hasVerifiedEmail()) {
-            return [
-                'status' => 'already-verified',
-                'user' => $user,
-            ];
+            return $this->buildVerificationResult($email, 'already-verified', $user);
         }
 
         $verificationCode = $this->emailVerificationCodeRepository->findByUserId($user->id);
 
         if ($verificationCode === null || $verificationCode->verified_at !== null) {
-            return [
-                'status' => 'invalid',
-                'user' => $user,
-            ];
+            return $this->buildVerificationResult($email, 'invalid', $user);
         }
 
         if ($verificationCode->expires_at->isPast()) {
-            return [
-                'status' => 'expired',
-                'user' => $user,
-            ];
+            return $this->buildVerificationResult($email, 'expired', $user);
         }
 
         if (! Hash::check($code, $verificationCode->code_hash)) {
-            return [
-                'status' => 'invalid',
-                'user' => $user,
-            ];
+            return $this->buildVerificationResult($email, 'invalid', $user);
         }
 
         $verifiedAt = now();
 
-        $this->userRepository->markEmailVerified($user, $verifiedAt);
+        $verifiedUser = $this->userRepository->markEmailVerified($user, $verifiedAt);
         $this->emailVerificationCodeRepository->markAsVerified($verificationCode, $verifiedAt);
 
-        return [
-            'status' => 'verified',
-            'user' => $user->fresh(),
-        ];
+        return $this->buildVerificationResult($email, 'verified', $verifiedUser);
     }
 
     /**
@@ -160,5 +149,23 @@ class EmailVerificationService
         $maximum = (10 ** $this->codeLength()) - 1;
 
         return (string) random_int($minimum, $maximum);
+    }
+
+    /**
+     * Return one verification result payload and emit the matching audit event.
+     *
+     * @param  string  $email
+     * @param  'verified'|'already-verified'|'invalid'|'expired'  $status
+     * @param  User|null  $user
+     * @return array{status:'verified'|'already-verified'|'invalid'|'expired',user:User|null}
+     */
+    private function buildVerificationResult(string $email, string $status, ?User $user): array
+    {
+        $this->authSecurityAuditService->logVerificationCodeChecked($email, $status, $user);
+
+        return [
+            'status' => $status,
+            'user' => $user,
+        ];
     }
 }

--- a/apps/laravel/tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php
@@ -8,6 +8,7 @@ use App\Enums\UserRole;
 use App\Models\AuthProvider;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 
 /**
@@ -171,6 +172,50 @@ class AdminAuthProviderApiControllerTest extends TestCase
     }
 
     /**
+     * Successful provider updates should emit a structured audit entry without leaking secret values.
+     */
+    public function test_admin_update_logs_auditable_provider_changes_without_secret_values(): void
+    {
+        Log::spy();
+
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'google']), [
+                'enabled' => true,
+                'visibility' => 'public',
+                'public_config' => [
+                    'client_id' => 'google-client-id',
+                    'redirect_uri' => 'https://example.com/auth/google/callback',
+                ],
+                'secret_config' => [
+                    'client_secret' => 'google-secret',
+                ],
+            ]);
+
+        $response->assertOk();
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($admin): bool {
+                $encodedContext = json_encode($context);
+
+                return $message === 'security.auth_provider_settings_updated'
+                    && $context['actor_user_id'] === $admin->id
+                    && $context['provider_key'] === 'google'
+                    && in_array('client_id', $context['changed_public_config_keys'], true)
+                    && in_array('redirect_uri', $context['changed_public_config_keys'], true)
+                    && in_array('client_secret', $context['changed_secret_config_keys'], true)
+                    && array_key_exists('enabled', $context['changed_attributes'])
+                    && is_string($encodedContext)
+                    && ! str_contains($encodedContext, 'google-secret');
+            });
+    }
+
+    /**
      * Email provider updates must persist the locked required verification policy.
      */
     public function test_admin_email_provider_update_forces_required_email_verification_mode(): void
@@ -245,6 +290,40 @@ class AdminAuthProviderApiControllerTest extends TestCase
     }
 
     /**
+     * Provider updates should reject unexpected nested config keys instead of storing free-form payloads.
+     */
+    public function test_admin_update_rejects_unexpected_nested_provider_config_keys(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'google']), [
+                'capabilities' => [
+                    'login' => true,
+                    'unexpected' => true,
+                ],
+                'public_config' => [
+                    'client_id' => 'google-client-id',
+                    'unexpected' => 'value',
+                ],
+                'secret_config' => [
+                    'client_secret' => 'google-secret',
+                    'unexpected' => 'value',
+                ],
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors([
+                'capabilities',
+                'public_config',
+                'secret_config',
+            ]);
+    }
+
+    /**
      * Email provider updates must reject verification policies weaker than required.
      */
     public function test_admin_update_rejects_non_required_email_verification_mode_for_email_provider(): void
@@ -287,5 +366,36 @@ class AdminAuthProviderApiControllerTest extends TestCase
 
         $response->assertUnprocessable()
             ->assertJsonValidationErrors(['enabled']);
+    }
+
+    /**
+     * The final working login path must stay usable even if a client submits capability changes directly.
+     */
+    public function test_admin_cannot_disable_last_active_login_capability(): void
+    {
+        $admin = User::factory()->create([
+            'role' => UserRole::Admin,
+        ]);
+
+        AuthProvider::query()->where('key', 'google')->update(['enabled' => false]);
+        AuthProvider::query()->where('key', 'facebook')->update(['enabled' => false]);
+        AuthProvider::query()->where('key', 'github')->update(['enabled' => false]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->putJson(route('api.admin.auth.providers.update', ['key' => 'email']), [
+                'enabled' => true,
+                'capabilities' => [
+                    'login' => false,
+                    'register' => true,
+                    'link_account' => false,
+                    'requires_redirect' => false,
+                    'supports_email_verification' => true,
+                    'supports_password' => true,
+                ],
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['capabilities.login']);
     }
 }

--- a/apps/laravel/tests/Feature/Controllers/Api/AuthApiControllerTest.php
+++ b/apps/laravel/tests/Feature/Controllers/Api/AuthApiControllerTest.php
@@ -13,6 +13,7 @@ use App\Notifications\QueuedVerifyEmailNotification;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Tests\TestCase;
@@ -335,6 +336,39 @@ class AuthApiControllerTest extends TestCase
     }
 
     /**
+     * Resend requests should emit an audit event without leaking the raw email address.
+     */
+    public function test_resend_verification_email_logs_audit_event(): void
+    {
+        Notification::fake();
+        Log::spy();
+
+        $user = User::factory()->create([
+            'email' => 'member@gmail.com',
+            'email_verified_at' => null,
+        ]);
+
+        $response = $this->postJson(route('api.auth.verification.send'), [
+            'email' => $user->email,
+        ]);
+
+        $response->assertOk();
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($user): bool {
+                $encodedContext = json_encode($context);
+
+                return $message === 'security.auth_verification_resend_requested'
+                    && $context['target_user_id'] === $user->id
+                    && $context['code_issued'] === true
+                    && is_string($context['email_hash'])
+                    && is_string($encodedContext)
+                    && ! str_contains($encodedContext, $user->email);
+            });
+    }
+
+    /**
      * A matching unexpired verification code should activate the user account.
      */
     public function test_it_marks_email_as_verified_from_a_valid_code(): void
@@ -371,6 +405,8 @@ class AuthApiControllerTest extends TestCase
      */
     public function test_it_rejects_an_invalid_email_verification_code(): void
     {
+        Log::spy();
+
         $user = User::factory()->unverified()->create([
             'email' => 'member@gmail.com',
         ]);
@@ -393,6 +429,19 @@ class AuthApiControllerTest extends TestCase
             ->assertJsonValidationErrors(['code']);
 
         $this->assertNull($user->fresh()?->email_verified_at);
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(function (string $message, array $context) use ($user): bool {
+                $encodedContext = json_encode($context);
+
+                return $message === 'security.auth_verification_code_checked'
+                    && $context['target_user_id'] === $user->id
+                    && $context['status'] === 'invalid'
+                    && is_string($context['email_hash'])
+                    && is_string($encodedContext)
+                    && ! str_contains($encodedContext, $user->email);
+            });
     }
 
     /**

--- a/apps/laravel/tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php
+++ b/apps/laravel/tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php
@@ -111,4 +111,35 @@ class AuthProviderConfigServiceTest extends TestCase
             $this->assertArrayHasKey('enabled', $errors);
         }
     }
+
+    /**
+     * Removing login capability from the final ready provider must be rejected like a hard disable.
+     */
+    public function test_update_rejects_disabling_last_active_login_capability(): void
+    {
+        $provider = AuthProvider::query()->where('key', 'email')->firstOrFail();
+
+        AuthProvider::query()->whereIn('key', ['google', 'facebook', 'github'])->update([
+            'enabled' => false,
+        ]);
+
+        try {
+            $this->app->make(AuthProviderConfigService::class)->update($provider, [
+                'capabilities' => [
+                    'login' => false,
+                    'register' => true,
+                    'link_account' => false,
+                    'requires_redirect' => false,
+                    'supports_email_verification' => true,
+                    'supports_password' => true,
+                ],
+            ]);
+
+            $this->fail('Expected validation exception was not thrown.');
+        } catch (ValidationException $exception) {
+            $errors = $exception->errors();
+
+            $this->assertArrayHasKey('capabilities.login', $errors);
+        }
+    }
 }

--- a/docs/rules/github-rules.md
+++ b/docs/rules/github-rules.md
@@ -4,6 +4,30 @@
 
 Use these rules whenever the task includes branch creation, staging, commits, pushes, force-pushes, or preparing PR and issue follow-up text.
 
+## Issue Naming
+
+- Use a single project key for this repository: `OPAS-xxxx`.
+- Issue identifiers should stay uppercase and zero-padded to 4 digits:
+  - `OPAS-0001`
+  - `OPAS-0042`
+  - `OPAS-0123`
+- Do not split issue identifiers into separate trackers such as `AUTH-0001` unless that area becomes a truly independent project with its own backlog and ownership.
+- Treat `AUTH`, `ADMIN`, `N8N`, `PYTHON`, `DOCS`, and similar values as domain tags in the issue title, not as separate issue key prefixes.
+- Start issue titles with one or more domain tags in square brackets, then a concise action-oriented summary.
+- Recommended title format:
+  - `[DOMAIN] Action + object`
+  - `[DOMAIN][SUBDOMAIN] Action + object`
+  - `[DOMAIN][SUBDOMAIN][DETAIL] Action + object`
+- Good examples:
+  - `OPAS-0001 [AUTH] Add Google OAuth login flow`
+  - `OPAS-0042 [AUTH] Rework authentication module`
+  - `OPAS-0043 [AUTH][LOGIN] Redesign login API`
+  - `OPAS-0044 [AUTH][REGISTER] Add email verification`
+  - `OPAS-0045 [AUTH][OAUTH] Add Google provider`
+  - `OPAS-0046 [AUTH][OAUTH][GITHUB] Add GitHub provider`
+  - `OPAS-0102 [DOCS] Define issue and branch naming convention`
+- When work has a parent-child relationship, keep the same `OPAS` issue key pattern for both parent and child issues and express the hierarchy through title tags, links, or issue relationships in GitHub rather than inventing a new key prefix.
+
 ## Branch Naming
 
 - Start new work on a dedicated branch from the intended base branch.
@@ -11,11 +35,25 @@ Use these rules whenever the task includes branch creation, staging, commits, pu
   - `feature/...` for user-facing or product feature work
   - `fix/...` for bug fixes or regressions
   - `chore/...` for tooling, docs, maintenance, or cleanup
-- Branch names should include the main topic or issue identifier when available.
+- Add `refactor/...` only when the change is structural and should not change behavior.
+- Add `hotfix/...` only for urgent production fixes.
+- Branch names should include the issue identifier when available and should stay lowercase.
+- Recommended branch format:
+  - `<type>/opas-xxxx-short-slug`
+- Use a short slug that summarizes the main change area after the issue identifier.
+- Prefer hyphen-separated words and keep the slug concise.
 - Good examples:
-  - `feature/google-oauth-issue-64`
-  - `fix/admin-sidebar-scroll-jitter`
-  - `chore/verification-rules`
+  - `feature/opas-0001-auth-google-oauth`
+  - `feature/opas-0045-auth-oauth-google-login`
+  - `fix/opas-0044-register-email-verification`
+  - `chore/opas-0102-docs-issue-branch-convention`
+  - `refactor/opas-0061-auth-service-cleanup`
+  - `hotfix/opas-0088-login-redirect-loop`
+- Avoid weak or inconsistent branch names such as:
+  - `feature/opas0001`
+  - `fix/OPAS-0001`
+  - `feature/auth`
+  - `branch-for-login-fix`
 
 ## Staging And Commit Scope
 


### PR DESCRIPTION
## Summary
Add security hardening around authentication settings and verification-related flows.

## What Changed
- added structured security audit logging for admin auth provider setting changes
- added verification-flow audit logging for resend and code verification outcomes
- hardened admin auth provider validation with nested allowlists and type checks
- blocked capability-level removal of the final working login path
- added regression coverage for protected admin actions, audit events, and config hardening

## Verification
- `php artisan test tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthApiControllerTest.php tests/Feature/Controllers/Api/AuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthProviderOAuthApiControllerTest.php tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php tests/Unit/Services/Auth/AuthProviderServiceTest.php tests/Unit/Services/Auth/EmailVerificationServiceTest.php`
- `./vendor/bin/pint app/Http/Controllers/Api/AdminAuthProviderApiController.php app/Http/Requests/UpdateAuthProviderRequest.php app/Services/Auth/AuthProviderConfigService.php app/Services/Auth/AuthSecurityAuditService.php app/Services/Auth/EmailVerificationService.php tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthApiControllerTest.php tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon app/Http/Controllers/Api/AdminAuthProviderApiController.php app/Http/Requests/UpdateAuthProviderRequest.php app/Services/Auth/AuthProviderConfigService.php app/Services/Auth/AuthSecurityAuditService.php app/Services/Auth/EmailVerificationService.php tests/Feature/Controllers/Api/AdminAuthProviderApiControllerTest.php tests/Feature/Controllers/Api/AuthApiControllerTest.php tests/Unit/Services/Auth/AuthProviderConfigServiceTest.php`

## Notes
- audit logs intentionally avoid raw secret values and raw email addresses
- no known residual blocker in the implemented issue scope

Closes #67
