### PR TITLE
Add Douyin workflow dashboard and service extension boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,18 @@ package-lock.json
 !services/n8n/nodes/package-lock.json
 npm-debug.log
 
+# ---- Local service extensions ----
+# New service source is developed separately by default. Add an explicit
+# allow-list entry here only when a service should be shipped with this repo.
+services/*
+!services/README.md
+!services/libretranslate/
+!services/libretranslate/**
+!services/n8n/
+!services/n8n/**
+!services/python/
+!services/python/**
+
 # Laravel test coverage
 apps/laravel/tests/_output/
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ LARAVEL-N8N-AUTOMATION/
 ├── docs/                         # Architecture and runbooks
 ├── nginx/                        # nginx configuration
 ├── services/
-│   ├── libretranslate/           # LibreTranslate service + Argos models
-│   ├── n8n/                      # n8n data, credentials, workflows
-│   └── python/                   # Python helper microservices
+│   ├── README.md                 # Service extension policy and notes
+│   ├── libretranslate/           # Default LibreTranslate service + Argos models
+│   ├── n8n/                      # Default n8n package/config scaffolding
+│   └── python/                   # Default Python helper microservices
 ├── scripts/                      # Automation scripts (macOS + Windows)
 ├── videos/
 ├── videos_uploaded/
@@ -174,6 +175,7 @@ LARAVEL-N8N-AUTOMATION/
 - `services/python/` replaces the old `python-services/` folder
 - `services/n8n/` replaces the old root `n8n/` folder
 - `services/libretranslate/` now contains both the LibreTranslate Docker setup and local Argos model packages
+- Additional service implementations are developed separately and connected only when intentionally enabled for a deployment. See `services/README.md`.
 
 ### Internal docs
 

--- a/apps/laravel/.env.example
+++ b/apps/laravel/.env.example
@@ -158,6 +158,10 @@ PYTHON_DOUYIN_PATH=/douyin
 PYTHON_CAPTION_PATH=/caption
 PYTHON_TRENDING_PATH=/trending
 
+DOUYIN_WORKER_URL=http://localhost:3101
+DOUYIN_WORKER_API_KEY=change_me_local_secret
+DOUYIN_VIDEO_STORAGE_DISK=local
+
 ########################################
 # Auto Coding
 ########################################

--- a/apps/laravel/README.md
+++ b/apps/laravel/README.md
@@ -41,6 +41,39 @@ Folder `apps/laravel/` trong repo nay dong vai tro:
 3. Tach them service/client rieng cho n8n webhook va external providers.
 4. Dung workflow CI chay `php artisan test`, `pint`, `phpstan`, `eslint`, `prettier`.
 
+## Douyin dashboard
+
+Laravel co man hinh `/douyin` de dieu khien workflow Douyin qua mot worker Node.js dat tai
+`services/douyin-worker` khi deployment chu dong bat workflow nay. Frontend chi goi Laravel API;
+Laravel moi goi worker bang `x-api-key`, khong expose secret ra SPA.
+
+Them env trong `apps/laravel/.env`:
+
+```env
+DOUYIN_WORKER_URL=http://localhost:3101
+DOUYIN_WORKER_API_KEY=change_me_local_secret
+DOUYIN_VIDEO_STORAGE_DISK=local
+```
+
+Chay local khi da co service implementation:
+
+```bash
+cd services/douyin-worker
+npm run dev
+
+cd apps/laravel
+php artisan migrate --seed
+npm run dev
+php artisan serve
+```
+
+Mo `http://localhost:8000/douyin`, chon keyword, bam `Crawl Preview`, bo cac video khong muon,
+roi bam `Process selected` de worker download video. Keyword mode lay URL truc tiep tu card search
+`waterfall_item_<videoId>`, khong scroll trong detail video de tranh lech sang related feed.
+
+MVP dang process selected dong bo trong controller nen neu download nhieu video co the cham hoac timeout.
+Phase sau nen chuyen process-selected sang Queue Job va cap nhat tien do theo polling/websocket.
+
 ## Lien ket tai lieu
 
 - `../docs/architecture.md`

--- a/apps/laravel/app/Http/Controllers/Api/DouyinApiController.php
+++ b/apps/laravel/app/Http/Controllers/Api/DouyinApiController.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CrawlDouyinRequest;
+use App\Http\Requests\MarkDouyinVideoPostedRequest;
+use App\Http\Requests\StoreDouyinKeywordRequest;
+use App\Http\Requests\UpdateDouyinVideoSelectionRequest;
+use App\Http\Resources\DouyinCrawlJobResource;
+use App\Http\Resources\DouyinKeywordResource;
+use App\Http\Resources\DouyinVideoResource;
+use App\Models\DouyinCrawlJob;
+use App\Models\DouyinVideo;
+use App\Services\Douyin\DouyinWorkflowService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use RuntimeException;
+
+class DouyinApiController extends Controller
+{
+    public function __construct(
+        private readonly DouyinWorkflowService $workflowService,
+    ) {}
+
+    /**
+     * List active Douyin keywords.
+     *
+     * @return JsonResponse
+     */
+    public function keywords(): JsonResponse
+    {
+        return DouyinKeywordResource::collection($this->workflowService->keywords())->response();
+    }
+
+    /**
+     * Store a Douyin keyword.
+     *
+     * @param  StoreDouyinKeywordRequest  $request
+     * @return JsonResponse
+     */
+    public function storeKeyword(StoreDouyinKeywordRequest $request): JsonResponse
+    {
+        /** @var array{name: string, category?: string|null} $validated */
+        $validated = $request->validated();
+        $keyword = $this->workflowService->createKeyword($validated);
+
+        return (new DouyinKeywordResource($keyword))->response()->setStatusCode(201);
+    }
+
+    /**
+     * Crawl preview videos for one keyword.
+     *
+     * @param  CrawlDouyinRequest  $request
+     * @return JsonResponse
+     */
+    public function crawl(CrawlDouyinRequest $request): JsonResponse
+    {
+        /** @var array{keyword: string, limit?: int|null} $validated */
+        $validated = $request->validated();
+
+        try {
+            $job = $this->workflowService->crawlPreview(
+                $validated['keyword'],
+                $validated['limit'] ?? 20
+            );
+        } catch (RuntimeException $exception) {
+            return $this->workerUnavailableResponse($exception);
+        }
+
+        return (new DouyinCrawlJobResource($job))->response()->setStatusCode(201);
+    }
+
+    /**
+     * List recent Douyin crawl jobs.
+     *
+     * @return JsonResponse
+     */
+    public function jobs(): JsonResponse
+    {
+        return DouyinCrawlJobResource::collection($this->workflowService->jobs())->response();
+    }
+
+    /**
+     * Show a crawl job with its videos.
+     *
+     * @param  DouyinCrawlJob  $job
+     * @return JsonResponse
+     */
+    public function showJob(DouyinCrawlJob $job): JsonResponse
+    {
+        return (new DouyinCrawlJobResource($job->load('videos')))->response();
+    }
+
+    /**
+     * Update video selection.
+     *
+     * @param  UpdateDouyinVideoSelectionRequest  $request
+     * @param  DouyinVideo  $video
+     * @return JsonResponse
+     */
+    public function updateSelection(UpdateDouyinVideoSelectionRequest $request, DouyinVideo $video): JsonResponse
+    {
+        $updatedVideo = $this->workflowService->updateSelection(
+            $video,
+            (bool) $request->validated('selected')
+        );
+
+        return (new DouyinVideoResource($updatedVideo))->response();
+    }
+
+    /**
+     * Download selected preview videos.
+     *
+     * @param  DouyinCrawlJob  $job
+     * @return JsonResponse
+     */
+    public function processSelected(DouyinCrawlJob $job): JsonResponse
+    {
+        try {
+            return DouyinVideoResource::collection(
+                $this->workflowService->processSelected($job)
+            )->response();
+        } catch (RuntimeException $exception) {
+            return $this->workerUnavailableResponse($exception);
+        }
+    }
+
+    /**
+     * List stored Douyin videos.
+     *
+     * @param  Request  $request
+     * @return JsonResponse
+     */
+    public function videos(Request $request): JsonResponse
+    {
+        /** @var array{status?: string|null, keyword?: string|null, page?: int|null} $filters */
+        $filters = $request->validate([
+            'status' => 'nullable|string|max:80',
+            'keyword' => 'nullable|string|max:255',
+            'page' => 'nullable|integer|min:1',
+        ]);
+
+        return DouyinVideoResource::collection($this->workflowService->videos($filters))->response();
+    }
+
+    /**
+     * Mark a video as posted.
+     *
+     * @param  MarkDouyinVideoPostedRequest  $request
+     * @param  DouyinVideo  $video
+     * @return JsonResponse
+     */
+    public function markPosted(MarkDouyinVideoPostedRequest $request, DouyinVideo $video): JsonResponse
+    {
+        $updatedVideo = $this->workflowService->markPosted(
+            $video,
+            (bool) ($request->validated('delete_after_posted') ?? false)
+        );
+
+        return (new DouyinVideoResource($updatedVideo))->response();
+    }
+
+    /**
+     * Delete a video and local files.
+     *
+     * @param  DouyinVideo  $video
+     * @return JsonResponse
+     */
+    public function destroyVideo(DouyinVideo $video): JsonResponse
+    {
+        $this->workflowService->deleteVideo($video);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Return a stable response when the worker is not enabled.
+     *
+     * @param  RuntimeException  $exception
+     * @return JsonResponse
+     */
+    private function workerUnavailableResponse(RuntimeException $exception): JsonResponse
+    {
+        return response()->json([
+            'message' => $exception->getMessage(),
+        ], 503);
+    }
+}

--- a/apps/laravel/app/Http/Requests/CrawlDouyinRequest.php
+++ b/apps/laravel/app/Http/Requests/CrawlDouyinRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CrawlDouyinRequest extends FormRequest
+{
+    /**
+     * Allow crawl requests through route middleware.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Normalize crawl keyword input.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        $keyword = $this->input('keyword');
+
+        $this->merge([
+            'keyword' => is_string($keyword) ? trim($keyword) : $keyword,
+        ]);
+    }
+
+    /**
+     * Get validation rules for crawl preview.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'keyword' => 'bail|required|string|max:255',
+            'limit' => 'nullable|integer|min:1|max:200',
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Requests/MarkDouyinVideoPostedRequest.php
+++ b/apps/laravel/app/Http/Requests/MarkDouyinVideoPostedRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MarkDouyinVideoPostedRequest extends FormRequest
+{
+    /**
+     * Allow posted transitions through route middleware.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get validation rules for posted transition.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'delete_after_posted' => 'nullable|boolean',
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Requests/StoreDouyinKeywordRequest.php
+++ b/apps/laravel/app/Http/Requests/StoreDouyinKeywordRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreDouyinKeywordRequest extends FormRequest
+{
+    /**
+     * Allow authenticated browser users through route middleware.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Normalize keyword text before validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        $name = $this->input('name');
+        $category = $this->input('category');
+
+        $this->merge([
+            'name' => is_string($name) ? trim($name) : $name,
+            'category' => is_string($category) ? trim($category) : $category,
+        ]);
+    }
+
+    /**
+     * Get validation rules for keyword creation.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'bail|required|string|max:255',
+            'category' => 'nullable|string|max:120',
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Requests/UpdateDouyinVideoSelectionRequest.php
+++ b/apps/laravel/app/Http/Requests/UpdateDouyinVideoSelectionRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDouyinVideoSelectionRequest extends FormRequest
+{
+    /**
+     * Allow selection changes through route middleware.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get validation rules for selected state.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'selected' => 'required|boolean',
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Resources/DouyinCrawlJobResource.php
+++ b/apps/laravel/app/Http/Resources/DouyinCrawlJobResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DouyinCrawlJob;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DouyinCrawlJobResource extends JsonResource
+{
+    /**
+     * Transform a Douyin crawl job into API fields.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var DouyinCrawlJob $resource */
+        $resource = $this->resource;
+
+        return [
+            'id' => $resource->id,
+            'keyword_id' => $resource->keyword_id,
+            'keyword' => $resource->keyword,
+            'limit' => $resource->limit,
+            'status' => $resource->status,
+            'total_found' => $resource->total_found,
+            'total_selected' => $resource->total_selected,
+            'total_downloaded' => $resource->total_downloaded,
+            'error_message' => $resource->error_message,
+            'started_at' => $resource->started_at?->toISOString(),
+            'finished_at' => $resource->finished_at?->toISOString(),
+            'created_at' => $resource->created_at?->toISOString(),
+            'videos_count' => $this->whenCounted('videos'),
+            'videos' => DouyinVideoResource::collection($this->whenLoaded('videos')),
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Resources/DouyinKeywordResource.php
+++ b/apps/laravel/app/Http/Resources/DouyinKeywordResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DouyinKeyword;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DouyinKeywordResource extends JsonResource
+{
+    /**
+     * Transform a Douyin keyword into API fields.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var DouyinKeyword $resource */
+        $resource = $this->resource;
+
+        return [
+            'id' => $resource->id,
+            'name' => $resource->name,
+            'category' => $resource->category,
+            'source' => $resource->source,
+            'priority' => $resource->priority,
+            'is_active' => $resource->is_active,
+            'last_crawled_at' => $resource->last_crawled_at?->toISOString(),
+        ];
+    }
+}

--- a/apps/laravel/app/Http/Resources/DouyinVideoResource.php
+++ b/apps/laravel/app/Http/Resources/DouyinVideoResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\DouyinVideo;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DouyinVideoResource extends JsonResource
+{
+    /**
+     * Transform a Douyin video into API fields.
+     *
+     * @param  Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        /** @var DouyinVideo $resource */
+        $resource = $this->resource;
+
+        return [
+            'id' => $resource->id,
+            'crawl_job_id' => $resource->crawl_job_id,
+            'keyword' => $resource->keyword,
+            'video_id' => $resource->video_id,
+            'source_url' => $resource->source_url,
+            'title' => $resource->title,
+            'author' => $resource->author,
+            'cover_url' => $resource->cover_url,
+            'duration' => $resource->duration,
+            'like_count' => $resource->like_count,
+            'local_path' => $resource->local_path,
+            'metadata_path' => $resource->metadata_path,
+            'selected' => $resource->selected,
+            'status' => $resource->status,
+            'error_message' => $resource->error_message,
+            'downloaded_at' => $resource->downloaded_at?->toISOString(),
+            'processed_at' => $resource->processed_at?->toISOString(),
+            'posted_at' => $resource->posted_at?->toISOString(),
+            'created_at' => $resource->created_at?->toISOString(),
+        ];
+    }
+}

--- a/apps/laravel/app/Models/DouyinCrawlJob.php
+++ b/apps/laravel/app/Models/DouyinCrawlJob.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Track one Douyin crawl-preview workflow.
+ *
+ * @property int $id
+ * @property int|null $keyword_id
+ * @property string $keyword
+ * @property int $limit
+ * @property string $status
+ */
+class DouyinCrawlJob extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'keyword_id',
+        'keyword',
+        'limit',
+        'status',
+        'total_found',
+        'total_selected',
+        'total_downloaded',
+        'error_message',
+        'started_at',
+        'finished_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+
+    /**
+     * Get the keyword record attached to this job.
+     *
+     * @return BelongsTo<DouyinKeyword, $this>
+     *
+     * @phpstan-return BelongsTo<DouyinKeyword, $this>
+     */
+    public function keywordRecord(): BelongsTo
+    {
+        return $this->belongsTo(DouyinKeyword::class, 'keyword_id');
+    }
+
+    /**
+     * Get videos discovered by this job.
+     *
+     * @return HasMany<DouyinVideo, $this>
+     *
+     * @phpstan-return HasMany<DouyinVideo, $this>
+     */
+    public function videos(): HasMany
+    {
+        return $this->hasMany(DouyinVideo::class, 'crawl_job_id');
+    }
+}

--- a/apps/laravel/app/Models/DouyinKeyword.php
+++ b/apps/laravel/app/Models/DouyinKeyword.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Persist reusable Douyin keyword inputs.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string|null $category
+ * @property string|null $source
+ * @property int $priority
+ * @property bool $is_active
+ */
+class DouyinKeyword extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'category',
+        'source',
+        'priority',
+        'is_active',
+        'last_crawled_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_active' => 'boolean',
+        'last_crawled_at' => 'datetime',
+    ];
+
+    /**
+     * Get crawl jobs created from this keyword.
+     *
+     * @return HasMany<DouyinCrawlJob, $this>
+     *
+     * @phpstan-return HasMany<DouyinCrawlJob, $this>
+     */
+    public function crawlJobs(): HasMany
+    {
+        return $this->hasMany(DouyinCrawlJob::class, 'keyword_id');
+    }
+}

--- a/apps/laravel/app/Models/DouyinVideo.php
+++ b/apps/laravel/app/Models/DouyinVideo.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Persist one Douyin video through preview and download states.
+ *
+ * @property int $id
+ * @property string $video_id
+ * @property string $source_url
+ * @property string $status
+ * @property bool $selected
+ */
+class DouyinVideo extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'crawl_job_id',
+        'keyword',
+        'video_id',
+        'source_url',
+        'title',
+        'author',
+        'cover_url',
+        'duration',
+        'like_count',
+        'local_path',
+        'metadata_path',
+        'selected',
+        'status',
+        'error_message',
+        'downloaded_at',
+        'processed_at',
+        'posted_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'selected' => 'boolean',
+        'downloaded_at' => 'datetime',
+        'processed_at' => 'datetime',
+        'posted_at' => 'datetime',
+    ];
+
+    /**
+     * Get the crawl job that discovered this video.
+     *
+     * @return BelongsTo<DouyinCrawlJob, $this>
+     *
+     * @phpstan-return BelongsTo<DouyinCrawlJob, $this>
+     */
+    public function crawlJob(): BelongsTo
+    {
+        return $this->belongsTo(DouyinCrawlJob::class, 'crawl_job_id');
+    }
+}

--- a/apps/laravel/app/Services/Douyin/DouyinWorkerClient.php
+++ b/apps/laravel/app/Services/Douyin/DouyinWorkerClient.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Douyin;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Call the internal Douyin worker service.
+ */
+class DouyinWorkerClient
+{
+    /**
+     * Crawl Douyin search results for one keyword.
+     *
+     * @param  string  $keyword
+     * @param  int  $limit
+     * @return array<string, mixed>
+     */
+    public function crawl(string $keyword, int $limit): array
+    {
+        return $this->post('/api/douyin/crawl', [
+            'keyword' => $keyword,
+            'limit' => $limit,
+        ]);
+    }
+
+    /**
+     * Download one Douyin video URL through the worker.
+     *
+     * @param  string  $url
+     * @return array<string, mixed>
+     */
+    public function download(string $url): array
+    {
+        return $this->post('/api/douyin/download', [
+            'url' => $url,
+            'quality' => 'best',
+            'networkWaitMs' => 12000,
+        ]);
+    }
+
+    /**
+     * Crawl and download in one worker request.
+     *
+     * @param  string  $keyword
+     * @param  int  $limit
+     * @return array<string, mixed>
+     */
+    public function crawlAndDownload(string $keyword, int $limit): array
+    {
+        return $this->post('/api/douyin/crawl-and-download', [
+            'keyword' => $keyword,
+            'limit' => $limit,
+            'download' => true,
+            'quality' => 'best',
+            'networkWaitMs' => 12000,
+        ]);
+    }
+
+    /**
+     * Create the configured HTTP client.
+     *
+     * @return PendingRequest
+     */
+    private function client(): PendingRequest
+    {
+        $configuredBaseUrl = config('services.douyin_worker.url');
+        $configuredApiKey = config('services.douyin_worker.api_key');
+        $baseUrl = is_string($configuredBaseUrl) ? $configuredBaseUrl : 'http://localhost:3101';
+        $apiKey = is_string($configuredApiKey) ? $configuredApiKey : '';
+
+        return Http::baseUrl(rtrim($baseUrl, '/'))
+            ->withHeaders(['x-api-key' => $apiKey])
+            ->acceptJson()
+            ->asJson()
+            ->timeout(300)
+            ->retry(2, 1000);
+    }
+
+    /**
+     * Send one POST request and unwrap worker data.
+     *
+     * @param  string  $path
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function post(string $path, array $payload): array
+    {
+        try {
+            $response = $this->client()->post($path, $payload);
+        } catch (ConnectionException $exception) {
+            throw new RuntimeException('Douyin worker service is not available.', 0, $exception);
+        }
+
+        if ($response->failed()) {
+            $message = $response->json('message');
+
+            throw new RuntimeException(
+                is_scalar($message) && (string) $message !== ''
+                    ? (string) $message
+                    : 'Douyin worker service returned an error.'
+            );
+        }
+
+        $data = $response->json('data');
+
+        if (! is_array($data)) {
+            throw new RuntimeException('Douyin worker returned an invalid response.');
+        }
+
+        /** @var array<string, mixed> $typedData */
+        $typedData = $data;
+
+        return $typedData;
+    }
+}

--- a/apps/laravel/app/Services/Douyin/DouyinWorkflowService.php
+++ b/apps/laravel/app/Services/Douyin/DouyinWorkflowService.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Douyin;
+
+use App\Models\DouyinCrawlJob;
+use App\Models\DouyinKeyword;
+use App\Models\DouyinVideo;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\File;
+use Throwable;
+
+/**
+ * Coordinate Douyin preview, selection, and download workflows.
+ */
+class DouyinWorkflowService
+{
+    public function __construct(
+        private readonly DouyinWorkerClient $workerClient,
+    ) {}
+
+    /**
+     * Return active Douyin keyword presets.
+     *
+     * @return Collection<int, DouyinKeyword>
+     */
+    public function keywords(): Collection
+    {
+        return DouyinKeyword::query()
+            ->where('is_active', true)
+            ->orderByDesc('priority')
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * Store a user-created Douyin keyword.
+     *
+     * @param  array{name: string, category?: string|null}  $payload
+     * @return DouyinKeyword
+     */
+    public function createKeyword(array $payload): DouyinKeyword
+    {
+        return DouyinKeyword::query()->updateOrCreate(
+            ['name' => $payload['name']],
+            [
+                'category' => $payload['category'] ?? null,
+                'source' => 'manual',
+                'is_active' => true,
+            ]
+        );
+    }
+
+    /**
+     * Crawl preview cards and persist discovered videos.
+     *
+     * @param  string  $keyword
+     * @param  int  $limit
+     * @return DouyinCrawlJob
+     */
+    public function crawlPreview(string $keyword, int $limit): DouyinCrawlJob
+    {
+        $keywordRecord = $this->resolveKeyword($keyword);
+        $job = $this->createCrawlingJob($keywordRecord, $keyword, $limit);
+
+        try {
+            $result = $this->workerClient->crawl($keyword, $limit);
+            $videos = $this->storePreviewVideos($job, $keyword, $this->normalizeItems($result['items'] ?? []));
+
+            $job->forceFill([
+                'status' => 'preview_ready',
+                'total_found' => $videos,
+                'total_selected' => $videos,
+                'finished_at' => now(),
+            ])->save();
+
+            $keywordRecord?->forceFill(['last_crawled_at' => now()])->save();
+
+            return $job->load('videos');
+        } catch (Throwable $throwable) {
+            $job->forceFill([
+                'status' => $this->isManualRequired($throwable) ? 'failed' : 'failed',
+                'error_message' => $throwable->getMessage(),
+                'finished_at' => now(),
+            ])->save();
+
+            throw $throwable;
+        }
+    }
+
+    /**
+     * Return recent crawl jobs.
+     *
+     * @return Collection<int, DouyinCrawlJob>
+     */
+    public function jobs(): Collection
+    {
+        return DouyinCrawlJob::query()
+            ->withCount('videos')
+            ->latest()
+            ->limit(30)
+            ->get();
+    }
+
+    /**
+     * Update whether a video should be processed.
+     *
+     * @param  DouyinVideo  $video
+     * @param  bool  $selected
+     * @return DouyinVideo
+     */
+    public function updateSelection(DouyinVideo $video, bool $selected): DouyinVideo
+    {
+        $video->forceFill([
+            'selected' => $selected,
+            'status' => $selected ? 'selected' : 'rejected',
+        ])->save();
+
+        $this->refreshJobTotals($video->crawlJob);
+
+        return $video->refresh();
+    }
+
+    /**
+     * Download selected videos for one job synchronously.
+     *
+     * @param  DouyinCrawlJob  $job
+     * @return Collection<int, DouyinVideo>
+     */
+    public function processSelected(DouyinCrawlJob $job): Collection
+    {
+        $job->forceFill(['status' => 'processing'])->save();
+
+        /** @var Collection<int, DouyinVideo> $videos */
+        $videos = $job->videos()
+            ->where('selected', true)
+            ->whereIn('status', ['preview', 'selected'])
+            ->get();
+
+        foreach ($videos as $video) {
+            $this->downloadVideo($video);
+        }
+
+        $this->refreshJobTotals($job);
+        $job->forceFill([
+            'status' => 'completed',
+            'finished_at' => now(),
+        ])->save();
+
+        return $job->videos()->latest()->get();
+    }
+
+    /**
+     * Paginate videos by optional filters.
+     *
+     * @param  array{status?: string|null, keyword?: string|null, page?: int|null}  $filters
+     * @return LengthAwarePaginator<int, DouyinVideo>
+     */
+    public function videos(array $filters): LengthAwarePaginator
+    {
+        return DouyinVideo::query()
+            ->when($filters['status'] ?? null, fn ($query, string $status) => $query->where('status', $status))
+            ->when($filters['keyword'] ?? null, fn ($query, string $keyword) => $query->where('keyword', $keyword))
+            ->latest()
+            ->paginate(24);
+    }
+
+    /**
+     * Mark a video posted and optionally delete local files.
+     *
+     * @param  DouyinVideo  $video
+     * @param  bool  $deleteAfterPosted
+     * @return DouyinVideo
+     */
+    public function markPosted(DouyinVideo $video, bool $deleteAfterPosted): DouyinVideo
+    {
+        if ($deleteAfterPosted) {
+            $this->deleteVideoFiles($video);
+        }
+
+        $video->forceFill([
+            'status' => 'posted',
+            'posted_at' => now(),
+            'local_path' => $deleteAfterPosted ? null : $video->local_path,
+            'metadata_path' => $deleteAfterPosted ? null : $video->metadata_path,
+        ])->save();
+
+        return $video->refresh();
+    }
+
+    /**
+     * Delete a video row and any local files.
+     *
+     * @param  DouyinVideo  $video
+     * @return void
+     */
+    public function deleteVideo(DouyinVideo $video): void
+    {
+        $job = $video->crawlJob;
+
+        $this->deleteVideoFiles($video);
+        $video->delete();
+        $this->refreshJobTotals($job);
+    }
+
+    /**
+     * Create a job in crawling status.
+     *
+     * @param  DouyinKeyword|null  $keywordRecord
+     * @param  string  $keyword
+     * @param  int  $limit
+     * @return DouyinCrawlJob
+     */
+    private function createCrawlingJob(?DouyinKeyword $keywordRecord, string $keyword, int $limit): DouyinCrawlJob
+    {
+        return DouyinCrawlJob::query()->create([
+            'keyword_id' => $keywordRecord?->id,
+            'keyword' => $keyword,
+            'limit' => $limit,
+            'status' => 'crawling',
+            'started_at' => now(),
+        ]);
+    }
+
+    /**
+     * Resolve an active keyword record when one exists.
+     *
+     * @param  string  $keyword
+     * @return DouyinKeyword|null
+     */
+    private function resolveKeyword(string $keyword): ?DouyinKeyword
+    {
+        return DouyinKeyword::query()->where('name', $keyword)->first();
+    }
+
+    /**
+     * Normalize worker items to arrays.
+     *
+     * @param  mixed  $items
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeItems(mixed $items): array
+    {
+        if (! is_array($items)) {
+            return [];
+        }
+
+        $normalizedItems = [];
+
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                /** @var array<string, mixed> $typedItem */
+                $typedItem = $item;
+                $normalizedItems[] = $typedItem;
+            }
+        }
+
+        return $normalizedItems;
+    }
+
+    /**
+     * Store preview video rows from worker cards.
+     *
+     * @param  DouyinCrawlJob  $job
+     * @param  string  $keyword
+     * @param  list<array<string, mixed>>  $items
+     * @return int
+     */
+    private function storePreviewVideos(DouyinCrawlJob $job, string $keyword, array $items): int
+    {
+        $stored = 0;
+
+        foreach ($items as $item) {
+            $videoId = $this->resolveVideoId($item);
+
+            if ($videoId === null) {
+                continue;
+            }
+
+            DouyinVideo::query()->updateOrCreate(
+                ['video_id' => $videoId],
+                [
+                    'crawl_job_id' => $job->id,
+                    'keyword' => $keyword,
+                    'source_url' => $this->resolveSourceUrl($item, $videoId),
+                    'title' => $this->nullableString($item['title'] ?? null),
+                    'author' => $this->nullableString($item['author'] ?? null),
+                    'selected' => true,
+                    'status' => 'preview',
+                    'error_message' => null,
+                ]
+            );
+            $stored++;
+        }
+
+        return $stored;
+    }
+
+    /**
+     * Resolve a video ID from worker payload fields.
+     *
+     * @param  array<string, mixed>  $item
+     * @return string|null
+     */
+    private function resolveVideoId(array $item): ?string
+    {
+        if (is_scalar($item['videoId'] ?? null) && (string) $item['videoId'] !== '') {
+            return (string) $item['videoId'];
+        }
+
+        $url = is_scalar($item['url'] ?? null) ? (string) $item['url'] : '';
+
+        if (preg_match('#/video/(\d+)#', $url, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Download one video and persist the worker result.
+     *
+     * @param  DouyinVideo  $video
+     * @return void
+     */
+    private function downloadVideo(DouyinVideo $video): void
+    {
+        $video->forceFill(['status' => 'downloading', 'error_message' => null])->save();
+
+        try {
+            $result = $this->workerClient->download($video->source_url);
+            $status = is_scalar($result['status'] ?? null) ? (string) $result['status'] : 'failed';
+
+            $video->forceFill([
+                'status' => in_array($status, ['downloaded', 'skipped'], true) ? 'downloaded' : 'failed',
+                'local_path' => $this->nullableString($result['localFile'] ?? null),
+                'metadata_path' => $this->nullableString($result['metadataFile'] ?? null),
+                'error_message' => $this->nullableString($result['error'] ?? null),
+                'downloaded_at' => in_array($status, ['downloaded', 'skipped'], true) ? now() : null,
+            ])->save();
+        } catch (Throwable $throwable) {
+            $video->forceFill([
+                'status' => 'failed',
+                'error_message' => $throwable->getMessage(),
+            ])->save();
+        }
+    }
+
+    /**
+     * Resolve the source URL from worker payload or video ID.
+     *
+     * @param  array<string, mixed>  $item
+     * @param  string  $videoId
+     * @return string
+     */
+    private function resolveSourceUrl(array $item, string $videoId): string
+    {
+        if (is_scalar($item['url'] ?? null) && (string) $item['url'] !== '') {
+            return (string) $item['url'];
+        }
+
+        return "https://www.douyin.com/video/{$videoId}";
+    }
+
+    /**
+     * Delete local paths attached to a video.
+     *
+     * @param  DouyinVideo  $video
+     * @return void
+     */
+    private function deleteVideoFiles(DouyinVideo $video): void
+    {
+        foreach ([$video->local_path, $video->metadata_path] as $path) {
+            if (is_string($path) && $path !== '' && File::exists($path)) {
+                File::delete($path);
+            }
+        }
+    }
+
+    /**
+     * Refresh aggregate totals for a crawl job.
+     *
+     * @param  DouyinCrawlJob|null  $job
+     * @return void
+     */
+    private function refreshJobTotals(?DouyinCrawlJob $job): void
+    {
+        if (! $job instanceof DouyinCrawlJob) {
+            return;
+        }
+
+        $job->forceFill([
+            'total_found' => $job->videos()->count(),
+            'total_selected' => $job->videos()->where('selected', true)->count(),
+            'total_downloaded' => $job->videos()->where('status', 'downloaded')->count(),
+        ])->save();
+    }
+
+    /**
+     * Convert mixed scalar values to nullable strings.
+     *
+     * @param  mixed  $value
+     * @return string|null
+     */
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $stringValue = trim((string) $value);
+
+        return $stringValue === '' ? null : $stringValue;
+    }
+
+    /**
+     * Determine if a worker error indicates manual browser action.
+     *
+     * @param  Throwable  $throwable
+     * @return bool
+     */
+    private function isManualRequired(Throwable $throwable): bool
+    {
+        return str_contains($throwable->getMessage(), 'MANUAL_REQUIRED');
+    }
+}

--- a/apps/laravel/config/services.php
+++ b/apps/laravel/config/services.php
@@ -109,4 +109,19 @@ return [
         'caption_path' => env('PYTHON_CAPTION_PATH', '/caption'),
         'trending_path' => env('PYTHON_TRENDING_PATH', '/trending'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Douyin Worker
+    |--------------------------------------------------------------------------
+    |
+    | Internal Node.js worker used for visible-browser Douyin crawling and
+    | downloading. The API key is never exposed to the frontend SPA.
+    |
+    */
+    'douyin_worker' => [
+        'url' => env('DOUYIN_WORKER_URL', 'http://localhost:3101'),
+        'api_key' => env('DOUYIN_WORKER_API_KEY'),
+        'video_storage_disk' => env('DOUYIN_VIDEO_STORAGE_DISK', 'local'),
+    ],
 ];

--- a/apps/laravel/database/migrations/2026_07_07_000001_create_douyin_keywords_table.php
+++ b/apps/laravel/database/migrations/2026_07_07_000001_create_douyin_keywords_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('douyin_keywords', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('category')->nullable();
+            $table->string('source')->nullable();
+            $table->unsignedInteger('priority')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('last_crawled_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('name');
+            $table->index(['is_active', 'priority']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('douyin_keywords');
+    }
+};

--- a/apps/laravel/database/migrations/2026_07_07_000002_create_douyin_crawl_jobs_table.php
+++ b/apps/laravel/database/migrations/2026_07_07_000002_create_douyin_crawl_jobs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('douyin_crawl_jobs', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('keyword_id')->nullable()->constrained('douyin_keywords')->nullOnDelete();
+            $table->string('keyword');
+            $table->unsignedInteger('limit')->default(20);
+            $table->string('status');
+            $table->unsignedInteger('total_found')->default(0);
+            $table->unsignedInteger('total_selected')->default(0);
+            $table->unsignedInteger('total_downloaded')->default(0);
+            $table->text('error_message')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['status', 'created_at']);
+            $table->index('keyword');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('douyin_crawl_jobs');
+    }
+};

--- a/apps/laravel/database/migrations/2026_07_07_000003_create_douyin_videos_table.php
+++ b/apps/laravel/database/migrations/2026_07_07_000003_create_douyin_videos_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('douyin_videos', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('crawl_job_id')->nullable()->constrained('douyin_crawl_jobs')->nullOnDelete();
+            $table->string('keyword')->nullable()->index();
+            $table->string('video_id')->unique();
+            $table->text('source_url');
+            $table->text('title')->nullable();
+            $table->string('author')->nullable();
+            $table->text('cover_url')->nullable();
+            $table->unsignedInteger('duration')->nullable();
+            $table->unsignedBigInteger('like_count')->nullable();
+            $table->text('local_path')->nullable();
+            $table->text('metadata_path')->nullable();
+            $table->boolean('selected')->default(true)->index();
+            $table->string('status')->default('preview')->index();
+            $table->text('error_message')->nullable();
+            $table->timestamp('downloaded_at')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('posted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('douyin_videos');
+    }
+};

--- a/apps/laravel/database/seeders/DatabaseSeeder.php
+++ b/apps/laravel/database/seeders/DatabaseSeeder.php
@@ -20,5 +20,6 @@ class DatabaseSeeder extends Seeder
         $this->call(FeedKeywordSeeder::class);
         $this->call(CoinAlertSettingsSeeder::class);
         $this->call(StockSeeder::class);
+        $this->call(DouyinKeywordSeeder::class);
     }
 }

--- a/apps/laravel/database/seeders/DouyinKeywordSeeder.php
+++ b/apps/laravel/database/seeders/DouyinKeywordSeeder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\DouyinKeyword;
+use Illuminate\Database\Seeder;
+
+class DouyinKeywordSeeder extends Seeder
+{
+    /**
+     * Seed preset Chinese keywords for Douyin workflows.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        foreach ($this->keywords() as $priority => $name) {
+            DouyinKeyword::query()->updateOrCreate(
+                ['name' => $name],
+                [
+                    'source' => 'preset',
+                    'priority' => $priority,
+                    'is_active' => true,
+                ]
+            );
+        }
+    }
+
+    /**
+     * Return the default keyword preset list.
+     *
+     * @return list<string>
+     */
+    private function keywords(): array
+    {
+        return [
+            '美女跳舞',
+            '小姐姐跳舞',
+            '穿搭',
+            '美妆',
+            '探店',
+            '街拍',
+            '搞笑',
+            '宠物',
+            '美食',
+            '健身',
+            '旅行',
+            '音乐',
+            '舞蹈',
+            '剧情',
+            '开箱',
+        ];
+    }
+}

--- a/apps/laravel/resources/js/spa/App.jsx
+++ b/apps/laravel/resources/js/spa/App.jsx
@@ -24,6 +24,7 @@ const CoinsPage = lazy(() => import('./features/coins/pages/CoinsPage'));
 const KeywordsPage = lazy(() => import('./features/coins/pages/KeywordsPage'));
 const StocksPage = lazy(() => import('./features/stocks/pages/StocksPage'));
 const VideosPage = lazy(() => import('./features/video-automation/pages/VideosPage'));
+const DouyinDashboardPage = lazy(() => import('./features/douyin/pages/DouyinDashboardPage'));
 
 /**
  * Root SPA router.
@@ -103,6 +104,10 @@ export default function App() {
                                             <Route
                                                 path="/video-automation/trending"
                                                 element={<VideosPage />}
+                                            />
+                                            <Route
+                                                path="/douyin"
+                                                element={<DouyinDashboardPage />}
                                             />
                                             <Route path="*" element={<Navigate to="/" replace />} />
                                         </Routes>

--- a/apps/laravel/resources/js/spa/components/layout/AppShell.jsx
+++ b/apps/laravel/resources/js/spa/components/layout/AppShell.jsx
@@ -84,6 +84,13 @@ export default function AppShell({ children }) {
             };
         }
 
+        if (location.pathname.startsWith('/douyin')) {
+            return {
+                title: t('shell.douyinTitle'),
+                description: t('shell.douyinDescription'),
+            };
+        }
+
         if (location.pathname.startsWith('/admin/auth/providers')) {
             return {
                 title: t('shell.authProvidersTitle'),

--- a/apps/laravel/resources/js/spa/config/navigation.js
+++ b/apps/laravel/resources/js/spa/config/navigation.js
@@ -75,6 +75,12 @@ export const navigation = [
                 icon: 'videos',
                 activePrefixes: ['/video-automation/trending'],
             },
+            {
+                labelKey: 'nav.douyinDashboard',
+                href: '/douyin',
+                icon: 'workflow',
+                activePrefixes: ['/douyin'],
+            },
         ],
     },
     {

--- a/apps/laravel/resources/js/spa/features/douyin/hooks/useDouyinDashboard.js
+++ b/apps/laravel/resources/js/spa/features/douyin/hooks/useDouyinDashboard.js
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    createDouyinKeyword,
+    crawlDouyinPreview,
+    deleteDouyinVideo,
+    getDouyinKeywords,
+    getDouyinVideos,
+    markDouyinVideoPosted,
+    processDouyinSelected,
+    updateDouyinVideoSelection,
+} from '../services/douyin.service';
+
+const defaultForm = {
+    keyword: '美女跳舞',
+    newKeyword: '',
+    category: '',
+    limit: 20,
+};
+
+/**
+ * Own Douyin dashboard data loading and workflow actions.
+ *
+ * @returns {{
+ *   form: { keyword: string, newKeyword: string, category: string, limit: number },
+ *   keywords: Array<Record<string, unknown>>,
+ *   previewVideos: Array<Record<string, unknown>>,
+ *   listedVideos: Array<Record<string, unknown>>,
+ *   currentJob: Record<string, unknown>|null,
+ *   activeStatus: string,
+ *   loading: boolean,
+ *   actionLoading: string,
+ *   error: string,
+ *   metrics: { preview: number, selected: number, downloaded: number },
+ *   setForm: import('react').Dispatch<import('react').SetStateAction<typeof defaultForm>>,
+ *   setActiveStatus: (status: string) => void,
+ *   selectKeyword: (keyword: string) => void,
+ *   addKeyword: () => Promise<void>,
+ *   crawlPreview: () => Promise<void>,
+ *   toggleVideoSelection: (video: Record<string, unknown>, selected: boolean) => Promise<void>,
+ *   selectAllPreview: (selected: boolean) => Promise<void>,
+ *   processSelected: () => Promise<void>,
+ *   markPosted: (video: Record<string, unknown>, deleteAfterPosted?: boolean) => Promise<void>,
+ *   deleteVideo: (video: Record<string, unknown>) => Promise<void>,
+ * }}
+ */
+export function useDouyinDashboard() {
+    const [form, setForm] = useState(defaultForm);
+    const [keywords, setKeywords] = useState([]);
+    const [previewVideos, setPreviewVideos] = useState([]);
+    const [listedVideos, setListedVideos] = useState([]);
+    const [currentJob, setCurrentJob] = useState(null);
+    const [activeStatus, setActiveStatus] = useState('preview');
+    const [loading, setLoading] = useState(true);
+    const [actionLoading, setActionLoading] = useState('');
+    const [error, setError] = useState('');
+
+    const refreshKeywords = useCallback(async () => {
+        const items = await getDouyinKeywords();
+        setKeywords(items);
+
+        if (!form.keyword && items[0]?.name) {
+            setForm((value) => ({ ...value, keyword: String(items[0].name) }));
+        }
+    }, [form.keyword]);
+
+    const refreshVideos = useCallback(async () => {
+        setListedVideos(await getDouyinVideos({ status: activeStatus }));
+    }, [activeStatus]);
+
+    useEffect(() => {
+        const loadInitialData = async () => {
+            setLoading(true);
+
+            try {
+                await Promise.all([refreshKeywords(), refreshVideos()]);
+                setError('');
+            } catch (error) {
+                setError(error.message || 'Unable to load Douyin dashboard data.');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        void loadInitialData();
+    }, [refreshKeywords, refreshVideos]);
+
+    const selectKeyword = useCallback((keyword) => {
+        setForm((value) => ({ ...value, keyword }));
+    }, []);
+
+    const addKeyword = useCallback(async () => {
+        if (!form.newKeyword.trim()) {
+            return;
+        }
+
+        setActionLoading('keyword');
+
+        try {
+            const keyword = await createDouyinKeyword({
+                name: form.newKeyword,
+                category: form.category,
+            });
+            setForm((value) => ({
+                ...value,
+                keyword: String(keyword.name ?? value.newKeyword),
+                newKeyword: '',
+                category: '',
+            }));
+            await refreshKeywords();
+            setError('');
+        } catch (error) {
+            setError(error.message || 'Unable to create Douyin keyword.');
+        } finally {
+            setActionLoading('');
+        }
+    }, [form.category, form.newKeyword, refreshKeywords]);
+
+    const crawlPreview = useCallback(async () => {
+        setActionLoading('crawl');
+
+        try {
+            const job = await crawlDouyinPreview({
+                keyword: form.keyword,
+                limit: Number(form.limit) || 20,
+            });
+            setCurrentJob(job);
+            setPreviewVideos(job.videos ?? []);
+            setActiveStatus('preview');
+            await refreshVideos();
+            setError('');
+        } catch (error) {
+            setError(
+                error.message ||
+                    'Unable to crawl preview videos. Check login, captcha, and worker status.',
+            );
+        } finally {
+            setActionLoading('');
+        }
+    }, [form.keyword, form.limit, refreshVideos]);
+
+    const replaceVideo = useCallback((updatedVideo) => {
+        setPreviewVideos((items) =>
+            items.map((item) => (item.id === updatedVideo.id ? updatedVideo : item)),
+        );
+        setListedVideos((items) =>
+            items.map((item) => (item.id === updatedVideo.id ? updatedVideo : item)),
+        );
+    }, []);
+
+    const toggleVideoSelection = useCallback(
+        async (video, selected) => {
+            const updatedVideo = await updateDouyinVideoSelection(video.id, selected);
+            replaceVideo(updatedVideo);
+        },
+        [replaceVideo],
+    );
+
+    const selectAllPreview = useCallback(
+        async (selected) => {
+            setActionLoading(selected ? 'select-all' : 'unselect-all');
+
+            try {
+                await Promise.all(
+                    previewVideos.map((video) => updateDouyinVideoSelection(video.id, selected)),
+                );
+                setPreviewVideos((items) =>
+                    items.map((item) => ({
+                        ...item,
+                        selected,
+                        status: selected ? 'selected' : 'rejected',
+                    })),
+                );
+                await refreshVideos();
+                setError('');
+            } catch (error) {
+                setError(error.message || 'Unable to update selected videos.');
+            } finally {
+                setActionLoading('');
+            }
+        },
+        [previewVideos, refreshVideos],
+    );
+
+    const processSelected = useCallback(async () => {
+        if (!currentJob?.id) {
+            return;
+        }
+
+        setActionLoading('process');
+
+        try {
+            const videos = await processDouyinSelected(currentJob.id);
+            setPreviewVideos(videos);
+            setActiveStatus('downloaded');
+            await refreshVideos();
+            setError('');
+        } catch (error) {
+            setError(
+                error.message ||
+                    'Unable to process selected videos. Download may need manual browser verification.',
+            );
+        } finally {
+            setActionLoading('');
+        }
+    }, [currentJob?.id, refreshVideos]);
+
+    const markPosted = useCallback(
+        async (video, deleteAfterPosted = false) => {
+            const updatedVideo = await markDouyinVideoPosted(video.id, deleteAfterPosted);
+            replaceVideo(updatedVideo);
+            await refreshVideos();
+        },
+        [refreshVideos, replaceVideo],
+    );
+
+    const deleteVideo = useCallback(
+        async (video) => {
+            await deleteDouyinVideo(video.id);
+            setPreviewVideos((items) => items.filter((item) => item.id !== video.id));
+            await refreshVideos();
+        },
+        [refreshVideos],
+    );
+
+    const metrics = useMemo(
+        () => ({
+            preview: previewVideos.length,
+            selected: previewVideos.filter((video) => video.selected).length,
+            downloaded: listedVideos.filter((video) => video.status === 'downloaded').length,
+        }),
+        [listedVideos, previewVideos],
+    );
+
+    return {
+        form,
+        keywords,
+        previewVideos,
+        listedVideos,
+        currentJob,
+        activeStatus,
+        loading,
+        actionLoading,
+        error,
+        metrics,
+        setForm,
+        setActiveStatus,
+        selectKeyword,
+        addKeyword,
+        crawlPreview,
+        toggleVideoSelection,
+        selectAllPreview,
+        processSelected,
+        markPosted,
+        deleteVideo,
+    };
+}

--- a/apps/laravel/resources/js/spa/features/douyin/pages/DouyinDashboardPage.jsx
+++ b/apps/laravel/resources/js/spa/features/douyin/pages/DouyinDashboardPage.jsx
@@ -1,0 +1,334 @@
+import Button from '../../../components/atoms/Button';
+import LoadingState from '../../../components/ui/LoadingState';
+import { useDouyinDashboard } from '../hooks/useDouyinDashboard';
+
+const tabs = [
+    { key: 'preview', label: 'Preview' },
+    { key: 'downloaded', label: 'Downloaded' },
+    { key: 'processing', label: 'Processing' },
+    { key: 'posted', label: 'Posted' },
+    { key: 'failed', label: 'Failed' },
+];
+
+/**
+ * Render the Douyin keyword-to-download dashboard.
+ */
+export default function DouyinDashboardPage() {
+    const dashboard = useDouyinDashboard();
+
+    if (dashboard.loading) {
+        return <LoadingState text="Loading Douyin dashboard..." />;
+    }
+
+    return (
+        <div className="app-shell douyin-dashboard">
+            <section className="app-hero douyin-hero">
+                <div className="app-hero__main">
+                    <p className="app-hero__eyebrow">Douyin Workflow</p>
+                    <h1 className="app-hero__title">Keyword preview to local video processing.</h1>
+                    <p className="app-hero__text">
+                        Crawl keyword result cards, reject weak previews, download selected videos,
+                        then move finished items to posted or delete/archive them.
+                    </p>
+                    <div className="app-inline-stats">
+                        <span className="app-chip">{dashboard.metrics.preview} preview</span>
+                        <span className="app-chip">{dashboard.metrics.selected} selected</span>
+                        <span className="app-chip">{dashboard.metrics.downloaded} downloaded</span>
+                    </div>
+                </div>
+                <div className="app-hero-card">
+                    <p className="app-hero-card__eyebrow">Active job</p>
+                    <h2 className="app-hero-card__title">
+                        {dashboard.currentJob?.keyword ?? 'No crawl yet'}
+                    </h2>
+                    <p className="app-hero-card__text">
+                        {dashboard.currentJob
+                            ? `${dashboard.currentJob.total_found ?? 0} found, ${dashboard.currentJob.total_selected ?? 0} selected`
+                            : 'Choose a keyword and crawl preview cards first.'}
+                    </p>
+                </div>
+            </section>
+
+            {dashboard.error ? <div className="douyin-alert">{dashboard.error}</div> : null}
+
+            <section className="app-surface douyin-controls">
+                <div>
+                    <p className="app-surface__title">Hot Keywords</p>
+                    <p className="app-surface__text">
+                        Presets come from the database. Add a manual keyword when the trend shifts.
+                    </p>
+                </div>
+
+                <div className="douyin-keyword-grid">
+                    {dashboard.keywords.map((keyword) => (
+                        <button
+                            className={`douyin-chip ${dashboard.form.keyword === keyword.name ? 'is-active' : ''}`}
+                            key={keyword.id}
+                            onClick={() => dashboard.selectKeyword(String(keyword.name))}
+                            type="button"
+                        >
+                            {keyword.name}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="douyin-form-grid">
+                    <label className="douyin-field">
+                        <span>Keyword</span>
+                        <input
+                            onChange={(event) =>
+                                dashboard.setForm((value) => ({
+                                    ...value,
+                                    keyword: event.target.value,
+                                }))
+                            }
+                            value={dashboard.form.keyword}
+                        />
+                    </label>
+                    <label className="douyin-field">
+                        <span>Limit</span>
+                        <input
+                            min="1"
+                            onChange={(event) =>
+                                dashboard.setForm((value) => ({
+                                    ...value,
+                                    limit: Number(event.target.value),
+                                }))
+                            }
+                            type="number"
+                            value={dashboard.form.limit}
+                        />
+                    </label>
+                    <Button
+                        loading={dashboard.actionLoading === 'crawl'}
+                        onClick={dashboard.crawlPreview}
+                    >
+                        Crawl Preview
+                    </Button>
+                </div>
+
+                <div className="douyin-form-grid">
+                    <label className="douyin-field">
+                        <span>New keyword</span>
+                        <input
+                            onChange={(event) =>
+                                dashboard.setForm((value) => ({
+                                    ...value,
+                                    newKeyword: event.target.value,
+                                }))
+                            }
+                            value={dashboard.form.newKeyword}
+                        />
+                    </label>
+                    <label className="douyin-field">
+                        <span>Category</span>
+                        <input
+                            onChange={(event) =>
+                                dashboard.setForm((value) => ({
+                                    ...value,
+                                    category: event.target.value,
+                                }))
+                            }
+                            value={dashboard.form.category}
+                        />
+                    </label>
+                    <Button
+                        loading={dashboard.actionLoading === 'keyword'}
+                        onClick={dashboard.addKeyword}
+                        variant="secondary"
+                    >
+                        Add Keyword
+                    </Button>
+                </div>
+            </section>
+
+            <section className="app-surface douyin-preview">
+                <div className="douyin-section-header">
+                    <div>
+                        <p className="app-surface__title">Preview Results</p>
+                        <p className="app-surface__text">
+                            Remove videos you do not want before running the download step.
+                        </p>
+                    </div>
+                    <div className="douyin-actions">
+                        <Button
+                            loading={dashboard.actionLoading === 'select-all'}
+                            onClick={() => dashboard.selectAllPreview(true)}
+                            size="sm"
+                            variant="secondary"
+                        >
+                            Select all
+                        </Button>
+                        <Button
+                            loading={dashboard.actionLoading === 'unselect-all'}
+                            onClick={() => dashboard.selectAllPreview(false)}
+                            size="sm"
+                            variant="ghost"
+                        >
+                            Unselect all
+                        </Button>
+                        <Button
+                            disabled={!dashboard.currentJob?.id || dashboard.metrics.selected === 0}
+                            loading={dashboard.actionLoading === 'process'}
+                            onClick={dashboard.processSelected}
+                        >
+                            Process selected
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="douyin-card-grid">
+                    {dashboard.previewVideos.map((video) => (
+                        <PreviewCard
+                            key={video.id}
+                            onDelete={dashboard.deleteVideo}
+                            onToggle={dashboard.toggleVideoSelection}
+                            video={video}
+                        />
+                    ))}
+                    {dashboard.previewVideos.length === 0 ? (
+                        <div className="douyin-empty">No preview cards yet.</div>
+                    ) : null}
+                </div>
+            </section>
+
+            <section className="app-surface douyin-library">
+                <div className="douyin-tabs">
+                    {tabs.map((tab) => (
+                        <button
+                            className={`douyin-tab ${dashboard.activeStatus === tab.key ? 'is-active' : ''}`}
+                            key={tab.key}
+                            onClick={() => dashboard.setActiveStatus(tab.key)}
+                            type="button"
+                        >
+                            {tab.label}
+                        </button>
+                    ))}
+                </div>
+                <VideoTable
+                    onDelete={dashboard.deleteVideo}
+                    onMarkPosted={dashboard.markPosted}
+                    videos={dashboard.listedVideos}
+                />
+            </section>
+        </div>
+    );
+}
+
+/**
+ * Render one preview card with selection controls.
+ *
+ * @param {{
+ *   video: Record<string, unknown>,
+ *   onToggle: (video: Record<string, unknown>, selected: boolean) => Promise<void>,
+ *   onDelete: (video: Record<string, unknown>) => Promise<void>,
+ * }} props
+ */
+function PreviewCard({ video, onToggle, onDelete }) {
+    const title = video.title || `Video ${video.video_id}`;
+
+    return (
+        <article className={`douyin-card ${video.selected ? 'is-selected' : 'is-rejected'}`}>
+            <div className="douyin-card__media">
+                {video.cover_url ? (
+                    <img alt="" src={video.cover_url} />
+                ) : (
+                    <span>{video.video_id}</span>
+                )}
+            </div>
+            <div className="douyin-card__body">
+                <h2>{title}</h2>
+                <p>{video.author || 'Unknown author'}</p>
+                <a href={video.source_url} rel="noreferrer" target="_blank">
+                    Open source
+                </a>
+            </div>
+            <div className="douyin-card__actions">
+                <label className="douyin-checkbox">
+                    <input
+                        checked={Boolean(video.selected)}
+                        onChange={(event) => onToggle(video, event.target.checked)}
+                        type="checkbox"
+                    />
+                    <span>Selected</span>
+                </label>
+                <Button
+                    onClick={() => onToggle(video, !video.selected)}
+                    size="sm"
+                    variant="secondary"
+                >
+                    {video.selected ? 'Reject' : 'Restore'}
+                </Button>
+                <Button onClick={() => onDelete(video)} size="sm" variant="danger">
+                    Delete
+                </Button>
+            </div>
+        </article>
+    );
+}
+
+/**
+ * Render videos by workflow status.
+ *
+ * @param {{
+ *   videos: Array<Record<string, unknown>>,
+ *   onMarkPosted: (video: Record<string, unknown>, deleteAfterPosted?: boolean) => Promise<void>,
+ *   onDelete: (video: Record<string, unknown>) => Promise<void>,
+ * }} props
+ */
+function VideoTable({ videos, onMarkPosted, onDelete }) {
+    if (videos.length === 0) {
+        return <div className="douyin-empty">No videos in this tab.</div>;
+    }
+
+    return (
+        <div className="douyin-table-wrap">
+            <table className="douyin-table">
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Keyword</th>
+                        <th>Status</th>
+                        <th>Local path</th>
+                        <th>Downloaded</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {videos.map((video) => (
+                        <tr key={video.id}>
+                            <td>{video.title || video.video_id}</td>
+                            <td>{video.keyword}</td>
+                            <td>
+                                <span className={`douyin-status douyin-status--${video.status}`}>
+                                    {video.status}
+                                </span>
+                            </td>
+                            <td>{video.local_path || '-'}</td>
+                            <td>{video.downloaded_at || '-'}</td>
+                            <td>
+                                <div className="douyin-table-actions">
+                                    <Button
+                                        disabled={video.status !== 'downloaded'}
+                                        onClick={() => onMarkPosted(video)}
+                                        size="sm"
+                                        variant="secondary"
+                                    >
+                                        Mark posted
+                                    </Button>
+                                    <Button
+                                        onClick={() => onDelete(video)}
+                                        size="sm"
+                                        variant="danger"
+                                    >
+                                        Delete
+                                    </Button>
+                                </div>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/apps/laravel/resources/js/spa/features/douyin/services/douyin.service.js
+++ b/apps/laravel/resources/js/spa/features/douyin/services/douyin.service.js
@@ -1,0 +1,106 @@
+import httpClient from '../../../api/httpClient';
+
+const LONG_WORKFLOW_TIMEOUT_MS = 600000;
+
+/**
+ * Load active Douyin keywords.
+ *
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function getDouyinKeywords() {
+    const response = await httpClient.get('/douyin/keywords');
+
+    return response.data.data ?? [];
+}
+
+/**
+ * Create one Douyin keyword.
+ *
+ * @param {{ name: string, category?: string }} payload
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function createDouyinKeyword(payload) {
+    const response = await httpClient.post('/douyin/keywords', payload);
+
+    return response.data.data;
+}
+
+/**
+ * Start a crawl preview request.
+ *
+ * @param {{ keyword: string, limit: number }} payload
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function crawlDouyinPreview(payload) {
+    const response = await httpClient.post('/douyin/crawl', payload, {
+        timeoutMs: LONG_WORKFLOW_TIMEOUT_MS,
+    });
+
+    return response.data.data;
+}
+
+/**
+ * Toggle a preview video's selected state.
+ *
+ * @param {number|string} id
+ * @param {boolean} selected
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function updateDouyinVideoSelection(id, selected) {
+    const response = await httpClient.patch(`/douyin/videos/${id}/selection`, { selected });
+
+    return response.data.data;
+}
+
+/**
+ * Process selected videos for one crawl job.
+ *
+ * @param {number|string} jobId
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function processDouyinSelected(jobId) {
+    const response = await httpClient.post(
+        `/douyin/jobs/${jobId}/process-selected`,
+        {},
+        { timeoutMs: LONG_WORKFLOW_TIMEOUT_MS },
+    );
+
+    return response.data.data ?? [];
+}
+
+/**
+ * Load stored Douyin videos by status.
+ *
+ * @param {{ status?: string, keyword?: string, page?: number }} filters
+ * @returns {Promise<Array<Record<string, unknown>>>}
+ */
+export async function getDouyinVideos(filters = {}) {
+    const response = await httpClient.get('/douyin/videos', { params: filters });
+
+    return response.data.data ?? [];
+}
+
+/**
+ * Mark one video posted.
+ *
+ * @param {number|string} id
+ * @param {boolean} deleteAfterPosted
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function markDouyinVideoPosted(id, deleteAfterPosted = false) {
+    const response = await httpClient.post(`/douyin/videos/${id}/mark-posted`, {
+        delete_after_posted: deleteAfterPosted,
+    });
+
+    return response.data.data;
+}
+
+/**
+ * Delete one Douyin video row and local files.
+ *
+ * @param {number|string} id
+ * @returns {Promise<void>}
+ */
+export async function deleteDouyinVideo(id) {
+    await httpClient.delete(`/douyin/videos/${id}`);
+}

--- a/apps/laravel/resources/js/spa/features/i18n/messages/en.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/en.js
@@ -31,6 +31,7 @@ export const enMessages = {
         stocks: 'Stocks',
         videoAutomation: 'Video Automation',
         trendingVideos: 'Trending Videos',
+        douyinDashboard: 'Douyin Dashboard',
         admin: 'Admin',
         authProviders: 'Auth Providers',
         telegramBots: 'Telegram Bots',
@@ -54,6 +55,9 @@ export const enMessages = {
         stocksDescription: 'Keep daily stock lists and watchlists in one place.',
         videosTitle: 'Trending Videos',
         videosDescription: 'Collect video sources for automation flows.',
+        douyinTitle: 'Douyin Dashboard',
+        douyinDescription:
+            'Crawl keyword previews, download selected videos, and track posting status.',
         authProvidersTitle: 'Auth Providers',
         authProvidersDescription:
             'Control which authentication methods are enabled and how each provider is configured.',

--- a/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
+++ b/apps/laravel/resources/js/spa/features/i18n/messages/vi.js
@@ -31,6 +31,7 @@ export const viMessages = {
         stocks: 'Stocks',
         videoAutomation: 'Tự động hóa video',
         trendingVideos: 'Video trending',
+        douyinDashboard: 'Douyin Dashboard',
         admin: 'Quản trị',
         authProviders: 'Kênh đăng nhập',
         telegramBots: 'Bot Telegram',
@@ -54,6 +55,9 @@ export const viMessages = {
         stocksDescription: 'Tập trung danh sách cổ phiếu và watchlist theo dõi hằng ngày.',
         videosTitle: 'Trending Videos',
         videosDescription: 'Tổng hợp nhóm video nguồn để xử lý automation.',
+        douyinTitle: 'Douyin Dashboard',
+        douyinDescription:
+            'Crawl preview theo keyword, tải video đã chọn và theo dõi trạng thái đăng.',
         authProvidersTitle: 'Nhà cung cấp đăng nhập',
         authProvidersDescription:
             'Bật tắt phương thức đăng nhập và quản lý cấu hình xác thực cho từng provider.',

--- a/apps/laravel/resources/scss/app.scss
+++ b/apps/laravel/resources/scss/app.scss
@@ -1,4 +1,5 @@
 @use './modules/confirm-modal';
+@use './modules/douyin-dashboard';
 
 :root {
     color-scheme: dark;

--- a/apps/laravel/resources/scss/modules/_douyin-dashboard.scss
+++ b/apps/laravel/resources/scss/modules/_douyin-dashboard.scss
@@ -1,0 +1,224 @@
+.douyin-dashboard {
+    --douyin-line: rgba(148, 163, 184, 0.2);
+}
+
+.douyin-hero .app-hero-card {
+    background: linear-gradient(160deg, #17324d 0%, #225269 54%, #2a7b78 100%);
+}
+
+.douyin-alert,
+.douyin-empty {
+    border: 1px solid rgba(248, 113, 113, 0.32);
+    border-radius: 16px;
+    padding: 1rem;
+    color: #fecaca;
+    background: rgba(127, 29, 29, 0.28);
+}
+
+.douyin-empty {
+    border-color: var(--douyin-line);
+    color: var(--opas-text-soft);
+    background: rgba(15, 23, 42, 0.52);
+}
+
+.douyin-controls,
+.douyin-preview,
+.douyin-library {
+    display: grid;
+    gap: 1rem;
+    padding: 1.25rem;
+}
+
+.douyin-keyword-grid,
+.douyin-actions,
+.douyin-tabs,
+.douyin-table-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.douyin-chip,
+.douyin-tab,
+.douyin-dashboard .app-chip {
+    border: 1px solid var(--douyin-line);
+    border-radius: 999px;
+    padding: 0.52rem 0.82rem;
+    color: var(--opas-text);
+    background: rgba(15, 23, 42, 0.68);
+    font-weight: 700;
+}
+
+.douyin-chip,
+.douyin-tab {
+    cursor: pointer;
+}
+
+.douyin-chip.is-active,
+.douyin-tab.is-active,
+.douyin-dashboard .app-chip {
+    border-color: rgba(34, 211, 238, 0.5);
+    color: #ecfeff;
+    background: linear-gradient(135deg, rgba(8, 145, 178, 0.52), rgba(37, 99, 235, 0.36));
+}
+
+.douyin-form-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) minmax(130px, 0.35fr) auto;
+    gap: 0.8rem;
+    align-items: end;
+}
+
+.douyin-field {
+    display: grid;
+    gap: 0.35rem;
+    color: var(--opas-text-soft);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.douyin-field input {
+    min-height: 44px;
+    border: 1px solid var(--douyin-line);
+    border-radius: 14px;
+    padding: 0.72rem 0.8rem;
+    color: var(--opas-text);
+    background: rgba(2, 6, 23, 0.72);
+}
+
+.douyin-field input:focus {
+    border-color: rgba(34, 211, 238, 0.62);
+    outline: none;
+}
+
+.douyin-section-header {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    justify-content: space-between;
+}
+
+.douyin-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.9rem;
+}
+
+.douyin-card {
+    display: grid;
+    gap: 0.8rem;
+    overflow: hidden;
+    border: 1px solid var(--douyin-line);
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.7);
+}
+
+.douyin-card.is-rejected {
+    opacity: 0.58;
+}
+
+.douyin-card__media {
+    display: grid;
+    place-items: center;
+    min-height: 140px;
+    color: var(--opas-text-soft);
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(8, 47, 73, 0.62));
+}
+
+.douyin-card__media img {
+    width: 100%;
+    height: 100%;
+    min-height: 140px;
+    object-fit: cover;
+}
+
+.douyin-card__body,
+.douyin-card__actions {
+    display: grid;
+    gap: 0.6rem;
+    padding: 0 0.9rem;
+}
+
+.douyin-card__actions {
+    padding-bottom: 0.9rem;
+}
+
+.douyin-card h2 {
+    margin: 0;
+    color: var(--opas-text-strong);
+    font-size: 1rem;
+}
+
+.douyin-card p {
+    margin: 0;
+    color: var(--opas-text-soft);
+}
+
+.douyin-card a {
+    color: #67e8f9;
+    font-weight: 700;
+}
+
+.douyin-checkbox {
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    color: var(--opas-text);
+}
+
+.douyin-table-wrap {
+    overflow-x: auto;
+}
+
+.douyin-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 820px;
+}
+
+.douyin-table th,
+.douyin-table td {
+    border-bottom: 1px solid var(--douyin-line);
+    padding: 0.82rem;
+    text-align: left;
+    vertical-align: top;
+}
+
+.douyin-table th {
+    color: var(--opas-text-soft);
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.douyin-status {
+    display: inline-flex;
+    border: 1px solid var(--douyin-line);
+    border-radius: 999px;
+    padding: 0.28rem 0.5rem;
+    color: var(--opas-text);
+    background: rgba(15, 23, 42, 0.68);
+}
+
+.douyin-status--downloaded,
+.douyin-status--posted {
+    border-color: rgba(74, 222, 128, 0.42);
+    color: #bbf7d0;
+}
+
+.douyin-status--failed,
+.douyin-status--rejected {
+    border-color: rgba(248, 113, 113, 0.42);
+    color: #fecaca;
+}
+
+@media (max-width: 760px) {
+    .douyin-form-grid,
+    .douyin-section-header {
+        grid-template-columns: 1fr;
+    }
+
+    .douyin-section-header {
+        display: grid;
+    }
+}

--- a/apps/laravel/routes/api.php
+++ b/apps/laravel/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\AuthProviderApiController;
 use App\Http\Controllers\Api\AuthProviderOAuthApiController;
 use App\Http\Controllers\Api\CoinAlertSettingApiController;
 use App\Http\Controllers\Api\CoinApiController;
+use App\Http\Controllers\Api\DouyinApiController;
 use App\Http\Controllers\Api\FavoriteCoinApiController;
 use App\Http\Controllers\Api\FavoriteStockApiController;
 use App\Http\Controllers\Api\FeedKeywordApiController;
@@ -182,5 +183,22 @@ Route::middleware('throttle:api')->group(function (): void {
     // Video automation APIs stay separate so feed-specific expansion remains isolated.
     Route::prefix('videos')->name('api.videos.')->group(function (): void {
         Route::get('/trending', [TrendingVideoApiController::class, 'index'])->name('trending.index');
+    });
+
+    // Douyin dashboard routes keep browser users behind Laravel while the worker API key stays server-side.
+    Route::prefix('douyin')->middleware(['web', 'auth', 'verified-email', 'no-store'])->name('api.douyin.')->group(function (): void {
+        Route::get('/keywords', [DouyinApiController::class, 'keywords'])->name('keywords.index');
+        Route::post('/keywords', [DouyinApiController::class, 'storeKeyword'])->name('keywords.store');
+        Route::post('/crawl', [DouyinApiController::class, 'crawl'])->name('crawl.store');
+        Route::get('/jobs', [DouyinApiController::class, 'jobs'])->name('jobs.index');
+        Route::get('/jobs/{job}', [DouyinApiController::class, 'showJob'])->name('jobs.show');
+        Route::post('/jobs/{job}/process-selected', [DouyinApiController::class, 'processSelected'])
+            ->name('jobs.process-selected');
+        Route::get('/videos', [DouyinApiController::class, 'videos'])->name('videos.index');
+        Route::patch('/videos/{video}/selection', [DouyinApiController::class, 'updateSelection'])
+            ->name('videos.selection');
+        Route::post('/videos/{video}/mark-posted', [DouyinApiController::class, 'markPosted'])
+            ->name('videos.mark-posted');
+        Route::delete('/videos/{video}', [DouyinApiController::class, 'destroyVideo'])->name('videos.destroy');
     });
 });

--- a/apps/laravel/routes/web.php
+++ b/apps/laravel/routes/web.php
@@ -35,6 +35,9 @@ Route::prefix('video-automation')->name('video-automation.')->group(function ():
     Route::view('/trending', 'spa')->name('trending.index');
 });
 
+// Douyin dashboard is a direct SPA entrypoint for the video sourcing workflow.
+Route::view('/douyin', 'spa')->name('douyin.index');
+
 // Keep a final SPA fallback for browser routes while excluding API endpoints.
 Route::view('/{any}', 'spa')
     ->where('any', '^(?!api).*$');

--- a/docs/roadmap/opas-douyin-video-subtitle-translation-vi.md
+++ b/docs/roadmap/opas-douyin-video-subtitle-translation-vi.md
@@ -1,0 +1,121 @@
+# Douyin Video Subtitle And Translation Backlog
+
+Ghi chu nay luu y tuong tuong lai cho pipeline:
+
+```text
+Douyin download
+  -> extract/normalize audio
+  -> speech-to-text with timestamps
+  -> subtitle segmentation
+  -> translate subtitle to Vietnamese / English
+  -> optional subtitle file or burned-in subtitle
+  -> optional YouTube upload metadata
+```
+
+## Context
+
+Ngay 2026-07-10, da kiem tra nhanh repo `Huanshere/VideoLingo`.
+
+Ket luan chinh:
+
+- VideoLingo khong phai cong cu bat tieng realtime tu tab web nhu OPAS realtime audio extension.
+- VideoLingo manh o huong xu ly video/audio da co san de tao subtitle, dich subtitle, va dubbing.
+- Phan dang can ghi nho cho OPAS la cach VideoLingo dung WhisperX cho ASR/subtitle-grade transcript.
+- Subtitle chua can lam ngay, nhung neu sau nay download video tu Douyin ve va muon co sub tieng Viet/tieng Anh thi day la huong "ngon an" de nghien cuu.
+
+## Candidate Approach
+
+Khi can lam tinh nang subtitle cho video Douyin da tai ve, uu tien thiet ke mot pipeline batch/offline rieng, khong tron voi realtime audio capture:
+
+1. Lay video tu `services/douyin-worker/storage/videos`.
+2. Tim metadata tu `services/douyin-worker/storage/metadata`.
+3. Dung FFmpeg de extract audio ve mono 16 kHz.
+4. Dung WhisperX de transcribe va align timestamp theo word/segment.
+5. Cat subtitle thanh cau ngan, de doc, phu hop Shorts/Reels/TikTok-style video.
+6. Dich subtitle sang `vi` hoac `en`.
+7. Xuat `.srt`/`.vtt` truoc; burn-in subtitle vao video chi lam sau khi can.
+8. Noi voi `services/youtube-uploader` neu can upload video da co subtitle/metadata.
+
+## Why WhisperX / VideoLingo Is Relevant
+
+VideoLingo dung cac y tuong phu hop voi bai toan video da tai ve:
+
+- WhisperX cho transcript co timestamp tot hon cho subtitle.
+- FFmpeg de extract/normalize audio.
+- Optional Demucs de tach vocal khi video co nhac nen/noise.
+- Subtitle segmentation rieng sau ASR, khong dung raw transcript truc tiep.
+- Dich va adapt subtitle sau khi da co timeline.
+
+Day co kha nang cho ket qua subtitle tot hon cach realtime STT hien tai vi realtime STT cua OPAS dang toi uu latency, khong toi uu word-level alignment.
+
+## Boundary With Realtime Audio Capture
+
+Khong thay the realtime audio capture bang VideoLingo.
+
+Hai huong nay khac nhau:
+
+- OPAS realtime audio capture: bat tieng tu browser tab/meeting/livestream dang phat, uu tien latency thap.
+- Douyin subtitle translation: xu ly video da download, uu tien subtitle chinh xac va dep.
+
+Neu can meeting/livestream realtime thi tiep tuc dung extension `chrome.tabCapture` va `faster-whisper`/streaming STT.
+
+Neu can video Douyin co sub dep de dang lai, dung huong WhisperX/VideoLingo-inspired batch pipeline.
+
+## Future Feature Slice
+
+Ten feature goi y:
+
+```text
+Douyin Subtitle Translation Pipeline
+```
+
+Scope MVP:
+
+- process mot file `.mp4` da download
+- output `.srt` song ngu hoac mot ngon ngu
+- support target `vi` va `en`
+- luu artifact canh video goc
+- khong burn subtitle trong MVP
+- khong dubbing trong MVP
+
+Scope later:
+
+- batch process selected Douyin videos tu Laravel UI
+- burn-in subtitle voi style rieng cho Shorts
+- auto-generate YouTube title/description tu transcript
+- choose provider: LibreTranslate, OpenAI, DeepL, Azure
+- optional vocal separation bang Demucs cho video nhieu nhac nen
+
+## Implementation Notes
+
+Khong nen dua logic nay vao Laravel controller.
+
+Vi tri phu hop hon:
+
+```text
+services/python/tool_video_subtitle_translation
+```
+
+Hoac neu muon gan rieng voi Douyin:
+
+```text
+services/python/tool_douyin_subtitle_translation
+```
+
+Laravel chi nen:
+
+- tao job
+- chon video
+- hien status
+- hien/download artifacts
+
+Worker/Python service nen:
+
+- doc video/audio
+- chay ASR
+- dich subtitle
+- ghi `.srt`, `.vtt`, va JSON artifact
+
+## Do Not Forget
+
+Khi operator noi ve viec "video Douyin download ve co sub tieng Viet/Anh", hay nho lai note nay va xem VideoLingo/WhisperX nhu reference chinh cho subtitle batch pipeline.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -137,7 +137,50 @@ Behavior:
 - `--docker`: always runs `php artisan queue:work` inside the `laravel` container
 - `--local`: always runs `php artisan queue:work` on the local machine
 
-## 0.7 macOS / Linux - `setup-telegram-webhook.sh`
+## 0.7 macOS / Linux - `douyin-youtube-once.sh`
+
+One-command Douyin keyword sourcing flow for Shorts-style videos.
+
+This workflow expects the Douyin worker and YouTube uploader service implementations
+to be present under `services/douyin-worker` and `services/youtube-uploader`.
+When those folders are not installed, the script exits with a clear missing-service
+message instead of trying to run a partial workflow.
+
+The script:
+- starts `services/douyin-worker` when it is not already running
+- crawls and downloads videos for one keyword
+- prints matched video/metadata JSON pairs for review
+- skips videos without matching JSON
+- ignores JSON files without matching videos
+- asks for confirmation before uploading matched pairs to YouTube
+
+```bash
+chmod +x scripts/douyin-youtube-once.sh
+scripts/douyin-youtube-once.sh --keyword "funny dance" --limit 10 --privacy private --hashtags "#shorts,#viral,#funny"
+```
+
+Run the default Chinese dance/beauty keyword batch and upload once at the end:
+
+```bash
+chmod +x scripts/douyin-youtube-dance-batch.sh
+scripts/douyin-youtube-dance-batch.sh --limit 3 --privacy private --hashtags "#shorts,#viral,#dance,#beauty,#trend"
+```
+
+Use `--delete-orphan-json` when you want metadata JSON without a matching video to be removed during the review step.
+
+Good starter keyword directions for Shorts are mostly visual and need little translation:
+- funny dance
+- dance challenge
+- street dance
+- funny reaction
+- comedy skit
+- magic trick
+- satisfying
+- gym fail
+- cute pet reaction
+- street performance
+
+## 0.8 macOS / Linux - `setup-telegram-webhook.sh`
 
 Inspect, register, delete, and sync Telegram bot commands for the auto-coding remote-control flow.
 
@@ -172,7 +215,7 @@ Behavior:
 - syncs Telegram bot commands automatically after successful registration
 - when started without arguments, shows an interactive menu for register / inspect / delete / sync
 
-## 0.8 macOS / Linux - `setup-telegram-ngrok.sh`
+## 0.9 macOS / Linux - `setup-telegram-ngrok.sh`
 
 One-command helper for local Telegram testing with ngrok.
 
@@ -272,7 +315,7 @@ Notes:
 - `stop` now stops both the ngrok tunnel and the background auto-coding worker process.
 - when started without arguments, shows an interactive menu for start / status / stop
 
-## 0.9 Windows - `setup-telegram-ngrok.ps1` / `setup-telegram-ngrok.bat`
+## 0.10 Windows - `setup-telegram-ngrok.ps1` / `setup-telegram-ngrok.bat`
 
 Windows versions of the one-command Telegram tunnel + webhook setup flow.
 
@@ -291,7 +334,7 @@ scripts\setup-telegram-ngrok.bat status
 scripts\setup-telegram-ngrok.bat stop
 ```
 
-## 0.10 Windows - `setup-telegram-webhook.ps1` / `setup-telegram-webhook.bat`
+## 0.11 Windows - `setup-telegram-webhook.ps1` / `setup-telegram-webhook.bat`
 
 Windows versions of the Telegram webhook management flow.
 

--- a/scripts/douyin-youtube-dance-batch.sh
+++ b/scripts/douyin-youtube-dance-batch.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+YOUTUBE_DIR="$ROOT_DIR/services/youtube-uploader"
+VIDEO_DIR="$ROOT_DIR/services/douyin-worker/storage/videos"
+METADATA_DIR="$ROOT_DIR/services/douyin-worker/storage/metadata"
+
+LIMIT="3"
+PRIVACY="private"
+HASHTAGS="#shorts,#viral,#dance,#beauty,#trend"
+PLAYLIST=""
+MADE_FOR_KIDS="no"
+DELETE_ORPHAN_JSON="1"
+
+KEYWORDS=(
+  "高颜值小姐姐 热舞"
+  "美女热舞"
+  "辣妹跳舞"
+  "高颜值小姐姐 舞蹈"
+  "小姐姐卡点舞"
+  "美女变装 热舞"
+)
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/douyin-youtube-dance-batch.sh [options]
+
+Options:
+  --limit NUMBER          Videos per keyword. Default: 3.
+  --privacy VALUE         YouTube privacy: private, unlisted, public. Default: private.
+  --hashtags TEXT         Comma-separated hashtags.
+  --playlist IDS          Comma-separated YouTube playlist IDs.
+  --made-for-kids VALUE   yes or no. Default: no.
+  --keep-orphan-json      Keep metadata JSON files that have no matching video.
+  --help                  Show this help.
+
+This runs the default viral dance/beauty keyword set, then asks once before upload.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    --privacy)
+      PRIVACY="${2:-}"
+      shift 2
+      ;;
+    --hashtags)
+      HASHTAGS="${2:-}"
+      shift 2
+      ;;
+    --playlist)
+      PLAYLIST="${2:-}"
+      shift 2
+      ;;
+    --made-for-kids)
+      MADE_FOR_KIDS="${2:-}"
+      shift 2
+      ;;
+    --keep-orphan-json)
+      DELETE_ORPHAN_JSON="0"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$ROOT_DIR/services/douyin-worker" ]]; then
+  echo "Missing service implementation: $ROOT_DIR/services/douyin-worker" >&2
+  echo "Add the Douyin worker service before running this workflow." >&2
+  exit 1
+fi
+
+if [[ ! -d "$YOUTUBE_DIR" ]]; then
+  echo "Missing service implementation: $YOUTUBE_DIR" >&2
+  echo "Add the YouTube uploader service before running this workflow." >&2
+  exit 1
+fi
+
+echo "Deleting old local Douyin videos, metadata, and crawl output before this batch..."
+find "$VIDEO_DIR" -maxdepth 1 -type f -name '*.mp4' -delete
+find "$METADATA_DIR" -maxdepth 1 -type f -name '*.json' -delete
+find "$ROOT_DIR/services/douyin-worker/storage/output" -maxdepth 1 -type f \( -name '*.json' -o -name '*.csv' \) -delete
+
+for keyword in "${KEYWORDS[@]}"; do
+  echo
+  echo "============================================================"
+  echo "Keyword: $keyword"
+  echo "============================================================"
+
+  "$ROOT_DIR/scripts/douyin-youtube-once.sh" \
+    --keyword "$keyword" \
+    --limit "$LIMIT" \
+    --privacy "$PRIVACY" \
+    --hashtags "$HASHTAGS" \
+    --keep-existing-records \
+    --no-upload
+done
+
+if [[ "$DELETE_ORPHAN_JSON" == "1" ]]; then
+  export VIDEO_DIR METADATA_DIR
+  node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+
+if (!fs.existsSync(videoDir) || !fs.existsSync(metadataDir)) {
+  process.exit(0);
+}
+
+const videoIds = new Set(
+  fs.readdirSync(videoDir)
+    .filter((file) => file.toLowerCase().endsWith('.mp4'))
+    .map((file) => path.basename(file, path.extname(file))),
+);
+
+for (const file of fs.readdirSync(metadataDir)) {
+  if (!file.toLowerCase().endsWith('.json')) {
+    continue;
+  }
+
+  const id = path.basename(file, path.extname(file));
+
+  if (!videoIds.has(id)) {
+    const metadataPath = path.join(metadataDir, file);
+    fs.rmSync(metadataPath, { force: true });
+    console.log(`Deleted orphan metadata: ${metadataPath}`);
+  }
+}
+NODE
+fi
+
+echo
+echo "Applying title language policy"
+echo "=============================="
+
+export VIDEO_DIR METADATA_DIR
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+const libreTranslateUrl = process.env.LIBRETRANSLATE_URL || 'http://localhost:5001';
+
+function listMatchedPairs() {
+  if (!fs.existsSync(videoDir) || !fs.existsSync(metadataDir)) {
+    return [];
+  }
+
+  return fs.readdirSync(videoDir)
+    .filter((file) => file.toLowerCase().endsWith('.mp4'))
+    .map((file) => {
+      const id = path.basename(file, path.extname(file));
+      const videoPath = path.join(videoDir, file);
+      const metadataPath = path.join(metadataDir, `${id}.json`);
+
+      return { id, videoPath, metadataPath, mtimeMs: fs.statSync(videoPath).mtimeMs };
+    })
+    .filter((pair) => fs.existsSync(pair.metadataPath))
+    .sort((left, right) => left.mtimeMs - right.mtimeMs || left.id.localeCompare(right.id));
+}
+
+async function translate(text, target) {
+  if (!text) {
+    return '';
+  }
+
+  if (target === 'vi') {
+    const english = await requestTranslate(text, 'auto', 'en');
+
+    return requestTranslate(english || text, 'en', 'vi');
+  }
+
+  return requestTranslate(text, 'auto', target);
+}
+
+async function requestTranslate(text, source, target) {
+  const response = await fetch(`${libreTranslateUrl}/translate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, source, target, format: 'text' }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`LibreTranslate failed with HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+
+  return typeof payload.translatedText === 'string' ? payload.translatedText.trim() : '';
+}
+
+async function titleFor(metadata, index) {
+  const originalTitle = typeof metadata.title === 'string' ? metadata.title.trim() : '';
+  const translatedTitle = typeof metadata.translatedTitle === 'string' ? metadata.translatedTitle.trim() : '';
+
+  if (index < 2) {
+    return { language: 'en', title: await translate(originalTitle, 'en') };
+  }
+
+  if (index < 4) {
+    return { language: 'zh', title: originalTitle };
+  }
+
+  return { language: 'vi', title: translatedTitle || (await translate(originalTitle, 'vi')) };
+}
+
+async function main() {
+  const pairs = listMatchedPairs();
+
+  for (let index = 0; index < pairs.length; index += 1) {
+    const pair = pairs[index];
+    const metadata = JSON.parse(fs.readFileSync(pair.metadataPath, 'utf8'));
+    const titlePolicy = await titleFor(metadata, index);
+
+    metadata.uploadTitle = titlePolicy.title || metadata.title || pair.id;
+    metadata.uploadTitleLanguage = titlePolicy.language;
+    fs.writeFileSync(pair.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+    console.log(`${index + 1}. ${pair.id} | ${titlePolicy.language} | ${metadata.uploadTitle}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+NODE
+
+echo
+echo "Final review before upload"
+echo "=========================="
+
+export VIDEO_DIR METADATA_DIR
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+function listFiles(dir, suffix) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  return fs.readdirSync(dir)
+    .filter((file) => file.toLowerCase().endsWith(suffix))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function readMetadata(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    return { __error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+const videos = listFiles(videoDir, '.mp4');
+const metadataIds = new Set(listFiles(metadataDir, '.json').map((file) => path.basename(file, path.extname(file))));
+let matchedCount = 0;
+
+for (const file of videos) {
+  const id = path.basename(file, path.extname(file));
+  const metadataPath = path.join(metadataDir, `${id}.json`);
+
+  if (!metadataIds.has(id)) {
+    console.log(`SKIP missing json: ${path.join(videoDir, file)}`);
+    continue;
+  }
+
+  const metadata = readMetadata(metadataPath);
+
+  if (metadata.__error) {
+    console.log(`SKIP invalid json: ${metadataPath} ${metadata.__error}`);
+    continue;
+  }
+
+  const videoPath = path.join(videoDir, file);
+  const sizeMb = fs.statSync(videoPath).size / 1024 / 1024;
+  const title = metadata.uploadTitle || metadata.translatedTitle || metadata.title || '(missing title)';
+  const language = metadata.uploadTitleLanguage || metadata.titleLanguage || 'unknown';
+  matchedCount += 1;
+  console.log(`${matchedCount}. ${id} | ${sizeMb.toFixed(1)} MB | ${language} | ${title}`);
+}
+
+console.log(`\nUploadable matched pairs: ${matchedCount}`);
+
+if (matchedCount === 0) {
+  process.exitCode = 2;
+}
+NODE
+
+review_status="$?"
+if [[ "$review_status" -eq 2 ]]; then
+  echo "No uploadable videos found."
+  exit 0
+fi
+
+if [[ "$review_status" -ne 0 ]]; then
+  exit "$review_status"
+fi
+
+echo
+read -r -p "Upload all matched videos to YouTube now? Type yes to upload: " upload_confirm
+
+if [[ "$upload_confirm" != "yes" ]]; then
+  echo "Upload cancelled."
+  exit 0
+fi
+
+if [[ ! -d "$YOUTUBE_DIR/node_modules" ]]; then
+  echo "Missing $YOUTUBE_DIR/node_modules. Run: cd services/youtube-uploader && npm install" >&2
+  exit 1
+fi
+
+upload_args=(-- --dir "$VIDEO_DIR" --privacy "$PRIVACY" --hashtags "$HASHTAGS" --made-for-kids "$MADE_FOR_KIDS" --require-metadata --delete-local-after-upload)
+
+if [[ -n "$PLAYLIST" ]]; then
+  upload_args+=(--playlist "$PLAYLIST")
+fi
+
+(cd "$YOUTUBE_DIR" && npm run upload:batch "${upload_args[@]}")
+
+echo "Deleting crawl output JSON/CSV after successful upload..."
+find "$ROOT_DIR/services/douyin-worker/storage/output" -maxdepth 1 -type f \( -name '*.json' -o -name '*.csv' \) -delete

--- a/scripts/douyin-youtube-once.sh
+++ b/scripts/douyin-youtube-once.sh
@@ -1,0 +1,522 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOUYIN_DIR="$ROOT_DIR/services/douyin-worker"
+YOUTUBE_DIR="$ROOT_DIR/services/youtube-uploader"
+VIDEO_DIR="$DOUYIN_DIR/storage/videos"
+METADATA_DIR="$DOUYIN_DIR/storage/metadata"
+
+KEYWORD=""
+LIMIT="10"
+PRIVACY="private"
+HASHTAGS="#shorts,#viral"
+PLAYLIST=""
+MADE_FOR_KIDS="no"
+QUALITY="best"
+NETWORK_WAIT_MS="15000"
+SLOW_START_MS="6000"
+WORKER_PORT="${DOUYIN_WORKER_PORT:-3101}"
+DELETE_ORPHAN_JSON="0"
+NO_UPLOAD="0"
+KEEP_EXISTING_RECORDS="0"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/douyin-youtube-once.sh --keyword "funny dance" [options]
+
+Options:
+  --keyword TEXT          Keyword used for Douyin search. Required.
+  --limit NUMBER          Number of videos to crawl/download. Default: 10.
+  --privacy VALUE         YouTube privacy: private, unlisted, public. Default: private.
+  --hashtags TEXT         Comma-separated hashtags. Default: #shorts,#viral.
+  --playlist IDS          Comma-separated YouTube playlist IDs.
+  --made-for-kids VALUE   yes or no. Default: no.
+  --quality VALUE         best or balanced. Default: best.
+  --network-wait-ms MS    Media network wait per video. Default: 15000.
+  --slow-start-ms MS      Search page warmup wait. Default: 6000.
+  --delete-orphan-json    Delete metadata JSON files that have no matching video.
+  --keep-existing-records Keep existing videos, metadata, and crawl output before this run.
+  --no-upload             Crawl/download/review only, then exit before the upload prompt.
+  --help                  Show this help.
+
+The script downloads first, prints a review of matched video/json pairs, then asks
+before uploading. Batch upload always requires matching metadata JSON.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keyword)
+      KEYWORD="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    --privacy)
+      PRIVACY="${2:-}"
+      shift 2
+      ;;
+    --hashtags)
+      HASHTAGS="${2:-}"
+      shift 2
+      ;;
+    --playlist)
+      PLAYLIST="${2:-}"
+      shift 2
+      ;;
+    --made-for-kids)
+      MADE_FOR_KIDS="${2:-}"
+      shift 2
+      ;;
+    --quality)
+      QUALITY="${2:-}"
+      shift 2
+      ;;
+    --network-wait-ms)
+      NETWORK_WAIT_MS="${2:-}"
+      shift 2
+      ;;
+    --slow-start-ms)
+      SLOW_START_MS="${2:-}"
+      shift 2
+      ;;
+    --delete-orphan-json)
+      DELETE_ORPHAN_JSON="1"
+      shift
+      ;;
+    --keep-existing-records)
+      KEEP_EXISTING_RECORDS="1"
+      shift
+      ;;
+    --no-upload)
+      NO_UPLOAD="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$KEYWORD" ]]; then
+  echo "Missing --keyword." >&2
+  usage >&2
+  exit 1
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+read_env_value() {
+  local file="$1"
+  local key="$2"
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  awk -F '=' -v key="$key" '
+    $1 == key {
+      value = substr($0, length(key) + 2)
+      gsub(/^["'\'']|["'\'']$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+require_command curl
+require_command node
+require_command npm
+
+if [[ ! -d "$DOUYIN_DIR" ]]; then
+  echo "Missing service implementation: $DOUYIN_DIR" >&2
+  echo "Add the Douyin worker service before running this workflow." >&2
+  exit 1
+fi
+
+if [[ ! -d "$YOUTUBE_DIR" ]]; then
+  echo "Missing service implementation: $YOUTUBE_DIR" >&2
+  echo "Add the YouTube uploader service before running this workflow." >&2
+  exit 1
+fi
+
+if [[ "$KEEP_EXISTING_RECORDS" != "1" ]]; then
+  echo "Deleting old local Douyin videos, metadata, and crawl output before this run..."
+  find "$VIDEO_DIR" -maxdepth 1 -type f -name '*.mp4' -delete
+  find "$METADATA_DIR" -maxdepth 1 -type f -name '*.json' -delete
+  find "$DOUYIN_DIR/storage/output" -maxdepth 1 -type f \( -name '*.json' -o -name '*.csv' \) -delete
+fi
+
+DOUYIN_WORKER_API_KEY="${DOUYIN_WORKER_API_KEY:-$(read_env_value "$DOUYIN_DIR/.env" "DOUYIN_WORKER_API_KEY")}"
+DOUYIN_WORKER_API_KEY="${DOUYIN_WORKER_API_KEY:-change_me_local_secret}"
+
+WORKER_PID=""
+
+cleanup() {
+  if [[ -n "$WORKER_PID" ]]; then
+    kill "$WORKER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+worker_health_url="http://127.0.0.1:$WORKER_PORT/health"
+worker_api_url="http://127.0.0.1:$WORKER_PORT/api/douyin/crawl-and-download"
+
+if curl -fsS "$worker_health_url" >/dev/null 2>&1; then
+  echo "Douyin worker is already running on port $WORKER_PORT."
+else
+  if [[ ! -d "$DOUYIN_DIR/node_modules" ]]; then
+    echo "Missing $DOUYIN_DIR/node_modules. Run: cd services/douyin-worker && npm install" >&2
+    exit 1
+  fi
+
+  echo "Starting Douyin worker on port $WORKER_PORT..."
+  (cd "$DOUYIN_DIR" && npm run dev) &
+  WORKER_PID="$!"
+
+  for _ in $(seq 1 60); do
+    if curl -fsS "$worker_health_url" >/dev/null 2>&1; then
+      break
+    fi
+
+    if ! kill -0 "$WORKER_PID" >/dev/null 2>&1; then
+      wait "$WORKER_PID" || true
+      echo "Douyin worker exited before it became ready. Run manually: cd services/douyin-worker && npm run dev" >&2
+      exit 1
+    fi
+
+    sleep 1
+  done
+
+  if ! curl -fsS "$worker_health_url" >/dev/null 2>&1; then
+    echo "Douyin worker did not become ready on port $WORKER_PORT." >&2
+    exit 1
+  fi
+fi
+
+export KEYWORD LIMIT QUALITY NETWORK_WAIT_MS SLOW_START_MS
+payload="$(
+  node -e '
+    const number = (value, fallback) => {
+      const parsed = Number.parseInt(String(value || ""), 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+    };
+
+    console.log(JSON.stringify({
+      keyword: process.env.KEYWORD,
+      limit: number(process.env.LIMIT, 10),
+      download: true,
+      quality: process.env.QUALITY === "balanced" ? "balanced" : "best",
+      networkWaitMs: number(process.env.NETWORK_WAIT_MS, 15000),
+      slowStartMs: number(process.env.SLOW_START_MS, 6000)
+    }));
+  '
+)"
+
+response_file="$(mktemp "${TMPDIR:-/tmp}/douyin-crawl-download.XXXXXX")"
+
+echo "Crawling and downloading keyword: $KEYWORD"
+curl -fsS \
+  -X POST "$worker_api_url" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $DOUYIN_WORKER_API_KEY" \
+  -d "$payload" \
+  -o "$response_file"
+
+echo "Crawl/download response saved to: $response_file"
+
+export VIDEO_DIR METADATA_DIR DELETE_ORPHAN_JSON
+set +e
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+const shouldDeleteOrphanJson = process.env.DELETE_ORPHAN_JSON === '1';
+
+function listFiles(dir, suffix) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  return fs.readdirSync(dir)
+    .filter((file) => file.toLowerCase().endsWith(suffix))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function readMetadata(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    return { __error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+const videos = listFiles(videoDir, '.mp4');
+const metadataFiles = listFiles(metadataDir, '.json');
+const videoIds = new Set(videos.map((file) => path.basename(file, path.extname(file))));
+const metadataIds = new Set(metadataFiles.map((file) => path.basename(file, path.extname(file))));
+const invalidJsonIds = [];
+const matchedIds = [...videoIds]
+  .filter((id) => {
+    if (!metadataIds.has(id)) {
+      return false;
+    }
+
+    const metadata = readMetadata(path.join(metadataDir, `${id}.json`));
+
+    if (metadata.__error) {
+      invalidJsonIds.push(id);
+      return false;
+    }
+
+    return true;
+  })
+  .sort((left, right) => left.localeCompare(right));
+const videosWithoutJson = [...videoIds].filter((id) => !metadataIds.has(id)).sort((left, right) => left.localeCompare(right));
+const jsonWithoutVideos = [...metadataIds].filter((id) => !videoIds.has(id)).sort((left, right) => left.localeCompare(right));
+
+console.log('\nReview before upload');
+console.log('====================');
+console.log(`Matched video/json pairs: ${matchedIds.length}`);
+
+for (const id of matchedIds) {
+  const videoPath = path.join(videoDir, `${id}.mp4`);
+  const metadataPath = path.join(metadataDir, `${id}.json`);
+  const metadata = readMetadata(metadataPath);
+  const sizeMb = fs.statSync(videoPath).size / 1024 / 1024;
+  const title = metadata.translatedTitle || metadata.title || '(missing title)';
+  const hashtags = Array.isArray(metadata.hashtags) ? metadata.hashtags.join(', ') : '';
+  const tags = Array.isArray(metadata.tags) ? metadata.tags.join(', ') : '';
+
+  console.log(`\n- ${id}`);
+  console.log(`  video: ${videoPath} (${sizeMb.toFixed(1)} MB)`);
+  console.log(`  json:  ${metadataPath}`);
+  console.log(`  title: ${title}`);
+  if (hashtags) console.log(`  hashtags: ${hashtags}`);
+  if (tags) console.log(`  tags: ${tags}`);
+  if (metadata.sourceUrl) console.log(`  source: ${metadata.sourceUrl}`);
+  if (metadata.__error) console.log(`  json_error: ${metadata.__error}`);
+}
+
+if (videosWithoutJson.length > 0) {
+  console.log('\nVideos skipped because metadata JSON is missing:');
+  for (const id of videosWithoutJson) {
+    console.log(`- ${path.join(videoDir, `${id}.mp4`)}`);
+  }
+}
+
+if (invalidJsonIds.length > 0) {
+  console.log('\nVideos skipped because metadata JSON is invalid:');
+  for (const id of invalidJsonIds) {
+    const metadataPath = path.join(metadataDir, `${id}.json`);
+    const metadata = readMetadata(metadataPath);
+    console.log(`- ${path.join(videoDir, `${id}.mp4`)}`);
+    console.log(`  json: ${metadataPath}`);
+    console.log(`  error: ${metadata.__error}`);
+  }
+}
+
+if (jsonWithoutVideos.length > 0) {
+  console.log('\nMetadata JSON ignored because matching video is missing:');
+  for (const id of jsonWithoutVideos) {
+    const metadataPath = path.join(metadataDir, `${id}.json`);
+    console.log(`- ${metadataPath}`);
+    if (shouldDeleteOrphanJson) {
+      fs.rmSync(metadataPath, { force: true });
+      console.log(`  deleted`);
+    }
+  }
+}
+
+if (matchedIds.length === 0) {
+  console.log('\nNo uploadable pairs found.');
+  process.exitCode = 2;
+}
+NODE
+
+review_status="$?"
+set -e
+if [[ "$review_status" -eq 2 ]]; then
+  exit 0
+fi
+
+if [[ "$review_status" -ne 0 ]]; then
+  exit "$review_status"
+fi
+
+if [[ "$NO_UPLOAD" == "1" ]]; then
+  echo
+  echo "Upload skipped because --no-upload was provided."
+  exit 0
+fi
+
+echo
+echo "Applying title language policy"
+echo "=============================="
+
+export VIDEO_DIR METADATA_DIR
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+const libreTranslateUrl = process.env.LIBRETRANSLATE_URL || 'http://localhost:5001';
+
+function listMatchedPairs() {
+  if (!fs.existsSync(videoDir) || !fs.existsSync(metadataDir)) {
+    return [];
+  }
+
+  return fs.readdirSync(videoDir)
+    .filter((file) => file.toLowerCase().endsWith('.mp4'))
+    .map((file) => {
+      const id = path.basename(file, path.extname(file));
+      const videoPath = path.join(videoDir, file);
+      const metadataPath = path.join(metadataDir, `${id}.json`);
+
+      return { id, videoPath, metadataPath, mtimeMs: fs.statSync(videoPath).mtimeMs };
+    })
+    .filter((pair) => fs.existsSync(pair.metadataPath))
+    .sort((left, right) => left.mtimeMs - right.mtimeMs || left.id.localeCompare(right.id));
+}
+
+async function translate(text, target) {
+  if (!text) {
+    return '';
+  }
+
+  if (target === 'vi') {
+    const english = await requestTranslate(text, 'auto', 'en');
+
+    return requestTranslate(english || text, 'en', 'vi');
+  }
+
+  return requestTranslate(text, 'auto', target);
+}
+
+async function requestTranslate(text, source, target) {
+  const response = await fetch(`${libreTranslateUrl}/translate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, source, target, format: 'text' }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`LibreTranslate failed with HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+
+  return typeof payload.translatedText === 'string' ? payload.translatedText.trim() : '';
+}
+
+async function titleFor(metadata, index) {
+  const originalTitle = typeof metadata.title === 'string' ? metadata.title.trim() : '';
+  const translatedTitle = typeof metadata.translatedTitle === 'string' ? metadata.translatedTitle.trim() : '';
+
+  if (index < 2) {
+    return { language: 'en', title: await translate(originalTitle, 'en') };
+  }
+
+  if (index < 4) {
+    return { language: 'zh', title: originalTitle };
+  }
+
+  return { language: 'vi', title: translatedTitle || (await translate(originalTitle, 'vi')) };
+}
+
+async function main() {
+  const pairs = listMatchedPairs();
+
+  for (let index = 0; index < pairs.length; index += 1) {
+    const pair = pairs[index];
+    const metadata = JSON.parse(fs.readFileSync(pair.metadataPath, 'utf8'));
+    const titlePolicy = await titleFor(metadata, index);
+
+    metadata.uploadTitle = titlePolicy.title || metadata.title || pair.id;
+    metadata.uploadTitleLanguage = titlePolicy.language;
+    fs.writeFileSync(pair.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+    console.log(`${index + 1}. ${pair.id} | ${titlePolicy.language} | ${metadata.uploadTitle}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+NODE
+
+node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const videoDir = process.env.VIDEO_DIR;
+const metadataDir = process.env.METADATA_DIR;
+
+const rows = fs.readdirSync(videoDir)
+  .filter((file) => file.toLowerCase().endsWith('.mp4'))
+  .map((file) => {
+    const id = path.basename(file, path.extname(file));
+    const videoPath = path.join(videoDir, file);
+    const metadataPath = path.join(metadataDir, `${id}.json`);
+
+    return { id, videoPath, metadataPath, mtimeMs: fs.statSync(videoPath).mtimeMs };
+  })
+  .filter((row) => fs.existsSync(row.metadataPath))
+  .sort((left, right) => left.mtimeMs - right.mtimeMs || left.id.localeCompare(right.id));
+
+console.log('\nUpload titles after language policy:');
+rows.forEach((row, index) => {
+  const metadata = JSON.parse(fs.readFileSync(row.metadataPath, 'utf8'));
+  const language = metadata.uploadTitleLanguage || 'unknown';
+  const title = metadata.uploadTitle || metadata.translatedTitle || metadata.title || '(missing title)';
+
+  console.log(`${index + 1}. ${row.id} | ${language} | ${title}`);
+});
+NODE
+
+echo
+echo "Review the JSON title/hashtags and open any video path above if needed."
+read -r -p "Upload matched pairs to YouTube now? Type yes to upload: " upload_confirm
+
+if [[ "$upload_confirm" != "yes" ]]; then
+  echo "Upload cancelled."
+  exit 0
+fi
+
+if [[ ! -d "$YOUTUBE_DIR/node_modules" ]]; then
+  echo "Missing $YOUTUBE_DIR/node_modules. Run: cd services/youtube-uploader && npm install" >&2
+  exit 1
+fi
+
+upload_args=(-- --dir "$VIDEO_DIR" --privacy "$PRIVACY" --hashtags "$HASHTAGS" --made-for-kids "$MADE_FOR_KIDS" --require-metadata --delete-local-after-upload)
+
+# Future Laravel control should resolve keyword -> playlistId from
+# services/youtube-uploader/config/playlist-routing.json instead of passing --playlist manually.
+if [[ -n "$PLAYLIST" ]]; then
+  upload_args+=(--playlist "$PLAYLIST")
+fi
+
+echo "Uploading matched video/json pairs to YouTube..."
+(cd "$YOUTUBE_DIR" && npm run upload:batch "${upload_args[@]}")
+
+echo "Deleting crawl output JSON/CSV after successful upload..."
+find "$DOUYIN_DIR/storage/output" -maxdepth 1 -type f \( -name '*.json' -o -name '*.csv' \) -delete

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,9 @@
+# Services
+
+This directory contains the default service scaffolding and integration points.
+
+Additional service implementations are developed separately and connected when
+they are intentionally enabled for a deployment.
+
+New service folders under `services/` are ignored by default unless they are
+explicitly allow-listed in the root `.gitignore`.


### PR DESCRIPTION
## Summary
- Add the Laravel Douyin workflow API, models, migrations, resources, and service layer.
- Add the React Douyin dashboard for keyword preview, video selection, processing, and status tracking.
- Add Douyin workflow scripts with clear missing-service messages when service implementations are not installed.
- Keep service implementations ignored by default while documenting the service extension boundary.

## Notes
- The public app now exposes the integration surface only.
- Douyin/YouTube service implementations are expected to be developed separately and connected intentionally per deployment.
- When the Douyin worker is unavailable, Laravel returns a stable 503 response instead of leaking worker details.

## Verification
- `./vendor/bin/pint --test`
- `./vendor/bin/phpstan analyse --memory-limit=-1 --no-progress --configuration=phpstan.neon`
- `npm run ci`
- `docker compose run --rm laravel php artisan test`